### PR TITLE
nobug: fix a bug where nil assertions did not work on some types

### DIFF
--- a/internal/assertions/assertions.go
+++ b/internal/assertions/assertions.go
@@ -74,15 +74,31 @@ func containsFunc[A any](slice []A, item A, eq func(a, b A) bool) bool {
 	return found
 }
 
+func isNil(a any) bool {
+	// comparable check only works for simple types
+	if a == nil {
+		return true
+	}
+
+	// check for non-nil nil types
+	value := reflect.ValueOf(a)
+	switch value.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Ptr, reflect.Slice:
+		return value.IsNil()
+	default:
+		return false
+	}
+}
+
 func Nil(a any) (s string) {
-	if a != nil {
+	if !isNil(a) {
 		s = "expected to be nil; is not nil"
 	}
 	return
 }
 
 func NotNil(a any) (s string) {
-	if a == nil {
+	if isNil(a) {
 		s = "expected to not be nil; is nil"
 	}
 	return

--- a/must/must_test.go
+++ b/must/must_test.go
@@ -18,13 +18,20 @@ func TestNil(t *testing.T) {
 	Nil(tc, 42)
 	Nil(tc, "hello")
 	Nil(tc, time.UTC)
+	Nil(tc, []string{"foo"})
+	Nil(tc, map[string]int{"foo": 1})
 }
 
 func TestNotNil(t *testing.T) {
 	tc := newCase(t, `expected to not be nil; is nil`)
 	t.Cleanup(tc.assert)
 
+	var s []string
+	var m map[string]int
+
 	NotNil(tc, nil)
+	NotNil(tc, s)
+	NotNil(tc, m)
 }
 
 func TestTrue(t *testing.T) {

--- a/test_test.go
+++ b/test_test.go
@@ -16,13 +16,20 @@ func TestNil(t *testing.T) {
 	Nil(tc, 42)
 	Nil(tc, "hello")
 	Nil(tc, time.UTC)
+	Nil(tc, []string{"foo"})
+	Nil(tc, map[string]int{"foo": 1})
 }
 
 func TestNotNil(t *testing.T) {
 	tc := newCase(t, `expected to not be nil; is nil`)
 	t.Cleanup(tc.assert)
 
+	var s []string
+	var m map[string]int
+
 	NotNil(tc, nil)
+	NotNil(tc, s)
+	NotNil(tc, m)
 }
 
 func TestTrue(t *testing.T) {


### PR DESCRIPTION
nil in Go is more complex than it seems; for some types we need to
use reflection to detect whether they are "really" nil, or if they
are typed nil - which as far as assertions go, would be treated as
nil
