### PR TITLE
gh-11: correctly handle nil errors

### DIFF
--- a/internal/assertions/assertions.go
+++ b/internal/assertions/assertions.go
@@ -126,6 +126,10 @@ func Error(err error) (s string) {
 }
 
 func EqError(err error, msg string) (s string) {
+	if err == nil {
+		s = "expected error; got nil"
+		return
+	}
 	e := err.Error()
 	if e != msg {
 		s = "expected matching error strings\n"
@@ -136,6 +140,10 @@ func EqError(err error, msg string) (s string) {
 }
 
 func ErrorIs(err error, target error) (s string) {
+	if err == nil {
+		s = "expected error; got nil"
+		return
+	}
 	if !errors.Is(err, target) {
 		s = "expected errors.Is match\n"
 		s += fmt.Sprintf("↪ error: %v\n", err)

--- a/must/must_test.go
+++ b/must/must_test.go
@@ -62,6 +62,13 @@ func TestEqError(t *testing.T) {
 	EqError(tc, errors.New("oops"), "blah")
 }
 
+func TestEqError_nil(t *testing.T) {
+	tc := newCase(t, `expected error; got nil`)
+	t.Cleanup(tc.assert)
+
+	EqError(tc, nil, "blah")
+}
+
 func TestErrorIs(t *testing.T) {
 	tc := newCase(t, `expected errors.Is match`)
 	t.Cleanup(tc.assert)
@@ -69,6 +76,14 @@ func TestErrorIs(t *testing.T) {
 	e1 := errors.New("foo")
 	e2 := errors.New("bar")
 	ErrorIs(tc, e1, e2)
+}
+
+func TestErrorIs_nil(t *testing.T) {
+	tc := newCase(t, `expected error; got nil`)
+	t.Cleanup(tc.assert)
+
+	err := errors.New("oops")
+	ErrorIs(tc, nil, err)
 }
 
 func TestNoError(t *testing.T) {

--- a/test_test.go
+++ b/test_test.go
@@ -60,6 +60,13 @@ func TestEqError(t *testing.T) {
 	EqError(tc, errors.New("oops"), "blah")
 }
 
+func TestEqError_nil(t *testing.T) {
+	tc := newCase(t, `expected error; got nil`)
+	t.Cleanup(tc.assert)
+
+	EqError(tc, nil, "blah")
+}
+
 func TestErrorIs(t *testing.T) {
 	tc := newCase(t, `expected errors.Is match`)
 	t.Cleanup(tc.assert)
@@ -67,6 +74,14 @@ func TestErrorIs(t *testing.T) {
 	e1 := errors.New("foo")
 	e2 := errors.New("bar")
 	ErrorIs(tc, e1, e2)
+}
+
+func TestErrorIs_nil(t *testing.T) {
+	tc := newCase(t, `expected error; got nil`)
+	t.Cleanup(tc.assert)
+
+	err := errors.New("oops")
+	ErrorIs(tc, nil, err)
 }
 
 func TestNoError(t *testing.T) {


### PR DESCRIPTION
EqError and ErrorIs will panic if the errors passed in
are actually nil. They should correctly handle the nil
error case.

Fixes #11