### PR TITLE
gh-22: provide a way to add more context on test failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,41 @@ a failure. Sometimes it is helpful for a test case to continue running even thou
 occurred (e.g. contains cleanup logic not captured via a `t.Cleanup` function). Other times it
 make sense to fail immediately and stop the test case execution.
 
+#### annotations
+
+Some tests are large and complex (like e2e testing). It can be helpful to provide more context
+on test case failures beyond the actual assertion. Logging could do this, but often we want to
+only produce output on failure.
+
+The `test` and `must` packages provide a `PostScript` interface which can be implemented to
+add more context in the output of failed tests. There are handy implementations of the `PostScript`
+interface provided - `Sprint`, `Sprintf`, `Values`, and `Func`.
+
+By adding one or more `PostScript` to an assertion, on failure the error message will be appended
+with the additional context.
+
+```golang
+// Add a single Sprintf-string to the output of a failed test assertion.
+must.Eq(t, exp, result, must.Sprintf("some more context: %v", value))
+```
+
+```golang
+// Add a formatted key-value map to the output of a failed test assertion.
+must.Eq(t, exp, result, must.Values(
+  "one", 1,
+  "two", 2,
+  "fruit", "banana",
+))
+```
+
+```golang
+// Add the output from a closure to the output of a failed test assertion.
+must.Eq(t, exp, result, must.Func(func() string {
+  // ... something interesting
+  return s
+})
+```
+
 `test` - functions allow test cases to continue execution
 
 `must` - functions stop test case execution immediately

--- a/interface.go
+++ b/interface.go
@@ -2,7 +2,6 @@
 package test
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/shoenig/test/internal/assertions"
@@ -19,14 +18,15 @@ func passing(result string) bool {
 	return result == ""
 }
 
-func fail(t T, msg string, args ...any) {
+func fail(t T, msg string, scripts ...PostScript) {
 	c := assertions.Caller()
-	s := c + fmt.Sprintf(msg, args...)
+	s := c + msg + "\n" + run(scripts...)
 	t.Errorf("\n" + strings.TrimSpace(s) + "\n")
 }
 
-func invoke(t T, result string) {
+func invoke(t T, result string, scripts ...PostScript) {
+	result = strings.TrimSpace(result)
 	if !passing(result) {
-		fail(t, result)
+		fail(t, result, scripts...)
 	}
 }

--- a/interface_test.go
+++ b/interface_test.go
@@ -6,12 +6,32 @@ import (
 	"testing"
 )
 
+type testScript struct {
+	label   string
+	content string
+}
+
+func (ts *testScript) Label() string {
+	return ts.label
+}
+
+func (ts *testScript) Content() string {
+	return ts.content
+}
+
 type internalTest struct {
 	t       *testing.T
 	trigger bool
 	helper  bool
 	exp     string
 	capture string
+}
+
+func (it *internalTest) PS(s string) PostScript {
+	return &testScript{
+		label:   "label: " + s,
+		content: "content: " + s,
+	}
 }
 
 func (it *internalTest) Helper() {
@@ -34,9 +54,14 @@ func (it *internalTest) assert() {
 	if !it.trigger {
 		it.t.Fatalf("condition expected to trigger; did not")
 	}
-
 	if !strings.Contains(it.capture, it.exp) {
 		it.t.Fatalf("expected message %q in output, got %q", it.exp, it.capture)
+	}
+}
+
+func (it *internalTest) post() {
+	if !strings.Contains(it.capture, "PostScript |") {
+		it.t.Fatal("expected post-script output")
 	}
 }
 
@@ -45,5 +70,11 @@ func newCase(t *testing.T, msg string) *internalTest {
 		t:       t,
 		trigger: false,
 		exp:     msg,
+	}
+}
+
+func newCapture(t *testing.T) *internalTest {
+	return &internalTest{
+		t: t,
 	}
 }

--- a/internal/assertions/assertions.go
+++ b/internal/assertions/assertions.go
@@ -33,10 +33,10 @@ func Caller() string {
 func diff[A, B any](a A, b B) (s string) {
 	defer func() {
 		if r := recover(); r != nil {
-			s = fmt.Sprintf("↪ comparison ↷\na: %#v\nb: %#v\n", a, b)
+			s = fmt.Sprintf("↪ Assertion | comparison ↷\na: %#v\nb: %#v\n", a, b)
 		}
 	}()
-	s = "↪ differential ↷\n" + cmp.Diff(a, b)
+	s = "↪ Assertion | differential ↷\n" + cmp.Diff(a, b)
 	return
 }
 

--- a/must/interface.go
+++ b/must/interface.go
@@ -2,7 +2,6 @@
 package must
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/shoenig/test/internal/assertions"
@@ -19,14 +18,14 @@ func passing(result string) bool {
 	return result == ""
 }
 
-func fail(t T, msg string, args ...any) {
+func fail(t T, msg string, scripts ...PostScript) {
 	c := assertions.Caller()
-	s := c + fmt.Sprintf(msg, args...)
+	s := c + msg + run(scripts...)
 	t.Fatalf("\n" + strings.TrimSpace(s) + "\n")
 }
 
-func invoke(t T, result string) {
+func invoke(t T, result string, scripts ...PostScript) {
 	if !passing(result) {
-		fail(t, result)
+		fail(t, result, scripts...)
 	}
 }

--- a/must/interface_test.go
+++ b/must/interface_test.go
@@ -6,12 +6,32 @@ import (
 	"testing"
 )
 
+type testScript struct {
+	label   string
+	content string
+}
+
+func (ts *testScript) Label() string {
+	return ts.label
+}
+
+func (ts *testScript) Content() string {
+	return ts.content
+}
+
 type internalTest struct {
 	t       *testing.T
 	trigger bool
 	helper  bool
 	exp     string
 	capture string
+}
+
+func (it *internalTest) PS(s string) PostScript {
+	return &testScript{
+		label:   "label: " + s,
+		content: "content: " + s,
+	}
 }
 
 func (it *internalTest) Helper() {
@@ -40,10 +60,22 @@ func (it *internalTest) assert() {
 	}
 }
 
+func (it *internalTest) post() {
+	if !strings.Contains(it.capture, "PostScript |") {
+		it.t.Fatal("expected post-script output")
+	}
+}
+
 func newCase(t *testing.T, msg string) *internalTest {
 	return &internalTest{
 		t:       t,
 		trigger: false,
 		exp:     msg,
+	}
+}
+
+func newCapture(t *testing.T) *internalTest {
+	return &internalTest{
+		t: t,
 	}
 }

--- a/must/must.go
+++ b/must/must.go
@@ -12,339 +12,339 @@ import (
 )
 
 // Nil asserts a is nil.
-func Nil(t T, a any) {
+func Nil(t T, a any, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.Nil(a))
+	invoke(t, assertions.Nil(a), scripts...)
 }
 
 // NotNil asserts a is not nil.
-func NotNil(t T, a any) {
+func NotNil(t T, a any, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.NotNil(a))
+	invoke(t, assertions.NotNil(a), scripts...)
 }
 
 // True asserts that condition is true.
-func True(t T, condition bool) {
+func True(t T, condition bool, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.True(condition))
+	invoke(t, assertions.True(condition), scripts...)
 }
 
 // False asserts condition is false.
-func False(t T, condition bool) {
+func False(t T, condition bool, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.False(condition))
+	invoke(t, assertions.False(condition), scripts...)
 }
 
 // Unreachable asserts a code path is not executed.
-func Unreachable(t T) {
+func Unreachable(t T, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.Unreachable())
+	invoke(t, assertions.Unreachable(), scripts...)
 }
 
 // Error asserts err is a non-nil error.
-func Error(t T, err error) {
+func Error(t T, err error, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.Error(err))
+	invoke(t, assertions.Error(err), scripts...)
 }
 
 // EqError asserts err contains message msg.
-func EqError(t T, err error, msg string) {
+func EqError(t T, err error, msg string, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.EqError(err, msg))
+	invoke(t, assertions.EqError(err, msg), scripts...)
 }
 
 // ErrorIs asserts err
-func ErrorIs(t T, err error, target error) {
+func ErrorIs(t T, err error, target error, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.ErrorIs(err, target))
+	invoke(t, assertions.ErrorIs(err, target), scripts...)
 }
 
 // NoError asserts err is a nil error.
-func NoError(t T, err error) {
+func NoError(t T, err error, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.NoError(err))
+	invoke(t, assertions.NoError(err), scripts...)
 }
 
 // Eq asserts a and b are equal using cmp.Equal.
-func Eq[A any](t T, a, b A) {
+func Eq[A any](t T, a, b A, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.Eq(a, b))
+	invoke(t, assertions.Eq(a, b), scripts...)
 }
 
 // EqOp asserts a == b.
-func EqOp[C comparable](t T, a, b C) {
+func EqOp[C comparable](t T, a, b C, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.EqOp(a, b))
+	invoke(t, assertions.EqOp(a, b), scripts...)
 }
 
 // EqFunc asserts a and b are equal using eq.
-func EqFunc[A any](t T, a, b A, eq func(a, b A) bool) {
+func EqFunc[A any](t T, a, b A, eq func(a, b A) bool, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.EqFunc(a, b, eq))
+	invoke(t, assertions.EqFunc(a, b, eq), scripts...)
 }
 
 // NotEq asserts a and b are not equal using cmp.Equal.
-func NotEq[A any](t T, a, b A) {
+func NotEq[A any](t T, a, b A, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.NotEq(a, b))
+	invoke(t, assertions.NotEq(a, b), scripts...)
 }
 
 // NotEqOp asserts a != b.
-func NotEqOp[C comparable](t T, a, b C) {
+func NotEqOp[C comparable](t T, a, b C, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.NotEqOp(a, b))
+	invoke(t, assertions.NotEqOp(a, b), scripts...)
 }
 
 // NotEqFunc asserts a and b are not equal using eq.
-func NotEqFunc[A any](t T, a, b A, eq func(a, b A) bool) {
+func NotEqFunc[A any](t T, a, b A, eq func(a, b A) bool, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.NotEqFunc(a, b, eq))
+	invoke(t, assertions.NotEqFunc(a, b, eq), scripts...)
 }
 
 // EqJSON asserts a and b are equivalent JSON.
-func EqJSON(t T, a, b string) {
+func EqJSON(t T, a, b string, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.EqJSON(a, b))
+	invoke(t, assertions.EqJSON(a, b), scripts...)
 }
 
 // EqSliceFunc asserts elements of a and b are the same using eq.
-func EqSliceFunc[A any](t T, a, b []A, eq func(a, b A) bool) {
+func EqSliceFunc[A any](t T, a, b []A, eq func(a, b A) bool, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.EqSliceFunc(a, b, eq))
+	invoke(t, assertions.EqSliceFunc(a, b, eq), scripts...)
 }
 
 // Equals asserts a.Equals(b).
-func Equals[E interfaces.EqualsFunc[E]](t T, a, b E) {
+func Equals[E interfaces.EqualsFunc[E]](t T, a, b E, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.Equals(a, b))
+	invoke(t, assertions.Equals(a, b), scripts...)
 }
 
 // NotEquals asserts !a.Equals(b).
-func NotEquals[E interfaces.EqualsFunc[E]](t T, a, b E) {
+func NotEquals[E interfaces.EqualsFunc[E]](t T, a, b E, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.NotEquals(a, b))
+	invoke(t, assertions.NotEquals(a, b), scripts...)
 }
 
 // EqualsSlice asserts a[n].Equals(b[n]) for each element n in slices a and b.
-func EqualsSlice[E interfaces.EqualsFunc[E]](t T, a, b []E) {
+func EqualsSlice[E interfaces.EqualsFunc[E]](t T, a, b []E, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.EqualsSlice(a, b))
+	invoke(t, assertions.EqualsSlice(a, b), scripts...)
 }
 
 // Lesser asserts a.Less(b).
-func Lesser[L interfaces.LessFunc[L]](t T, a, b L) {
+func Lesser[L interfaces.LessFunc[L]](t T, a, b L, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.Lesser(a, b))
+	invoke(t, assertions.Lesser(a, b), scripts...)
 }
 
 // EmptySlice asserts slice is empty.
-func EmptySlice[A any](t T, slice []A) {
+func EmptySlice[A any](t T, slice []A, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.EmptySlice(slice))
+	invoke(t, assertions.EmptySlice(slice), scripts...)
 }
 
 // Empty asserts slice is empty.
 //
 // Convenience function for EmptySlice.
-func Empty[A any](t T, slice []A) {
+func Empty[A any](t T, slice []A, scripts ...PostScript) {
 	t.Helper()
-	EmptySlice(t, slice)
+	EmptySlice(t, slice, scripts...)
 }
 
 // LenSlice asserts slice is of length n.
-func LenSlice[A any](t T, n int, slice []A) {
+func LenSlice[A any](t T, n int, slice []A, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.LenSlice(n, slice))
+	invoke(t, assertions.LenSlice(n, slice), scripts...)
 }
 
 // Len asserts slice is of length n.
 //
 // Convenience function for LenSlice.
-func Len[A any](t T, n int, slice []A) {
+func Len[A any](t T, n int, slice []A, scripts ...PostScript) {
 	t.Helper()
-	LenSlice(t, n, slice)
+	invoke(t, assertions.LenSlice(n, slice), scripts...)
 }
 
 // Contains asserts item exists in slice using cmp.Equal function.
-func Contains[A any](t T, slice []A, item A) {
+func Contains[A any](t T, slice []A, item A, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.Contains(slice, item))
+	invoke(t, assertions.Contains(slice, item), scripts...)
 }
 
 // ContainsOp asserts item exists in slice using == operator.
-func ContainsOp[C comparable](t T, slice []C, item C) {
+func ContainsOp[C comparable](t T, slice []C, item C, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.ContainsOp(slice, item))
+	invoke(t, assertions.ContainsOp(slice, item), scripts...)
 }
 
 // ContainsFunc asserts item exists in slice, using eq to compare elements.
-func ContainsFunc[A any](t T, slice []A, item A, eq func(a, b A) bool) {
+func ContainsFunc[A any](t T, slice []A, item A, eq func(a, b A) bool, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.ContainsFunc(slice, item, eq))
+	invoke(t, assertions.ContainsFunc(slice, item, eq), scripts...)
 }
 
 // ContainsEquals asserts item exists in slice, using Equals to compare elements.
-func ContainsEquals[E interfaces.EqualsFunc[E]](t T, slice []E, item E) {
+func ContainsEquals[E interfaces.EqualsFunc[E]](t T, slice []E, item E, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.ContainsEquals(slice, item))
+	invoke(t, assertions.ContainsEquals(slice, item), scripts...)
 }
 
 // ContainsString asserts s contains sub.
-func ContainsString(t T, s, sub string) {
+func ContainsString(t T, s, sub string, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.ContainsString(s, sub))
+	invoke(t, assertions.ContainsString(s, sub), scripts...)
 }
 
 // Positive asserts n > 0.
-func Positive[N interfaces.Number](t T, n N) {
+func Positive[N interfaces.Number](t T, n N, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.Positive(n))
+	invoke(t, assertions.Positive(n), scripts...)
 }
 
 // Negative asserts n < 0.
-func Negative[N interfaces.Number](t T, n N) {
+func Negative[N interfaces.Number](t T, n N, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.Negative(n))
+	invoke(t, assertions.Negative(n), scripts...)
 }
 
 // Zero asserts n == 0.
-func Zero[N interfaces.Number](t T, n N) {
+func Zero[N interfaces.Number](t T, n N, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.Zero(n))
+	invoke(t, assertions.Zero(n), scripts...)
 }
 
 // NonZero asserts n != 0.
-func NonZero[N interfaces.Number](t T, n N) {
+func NonZero[N interfaces.Number](t T, n N, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.NonZero(n))
+	invoke(t, assertions.NonZero(n), scripts...)
 }
 
 // Less asserts a < b.
-func Less[O constraints.Ordered](t T, a, b O) {
+func Less[O constraints.Ordered](t T, a, b O, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.Less(a, b))
+	invoke(t, assertions.Less(a, b), scripts...)
 }
 
 // LessEq asserts a <= b.
-func LessEq[O constraints.Ordered](t T, a, b O) {
+func LessEq[O constraints.Ordered](t T, a, b O, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.LessEq(a, b))
+	invoke(t, assertions.LessEq(a, b), scripts...)
 }
 
 // Greater asserts a > b.
-func Greater[O constraints.Ordered](t T, a, b O) {
+func Greater[O constraints.Ordered](t T, a, b O, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.Greater(a, b))
+	invoke(t, assertions.Greater(a, b), scripts...)
 }
 
 // GreaterEq asserts a >= b.
-func GreaterEq[O constraints.Ordered](t T, a, b O) {
+func GreaterEq[O constraints.Ordered](t T, a, b O, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.GreaterEq(a, b))
+	invoke(t, assertions.GreaterEq(a, b), scripts...)
 }
 
 // Ascending asserts slice[n] <= slice[n+1] for each element n.
-func Ascending[O constraints.Ordered](t T, slice []O) {
+func Ascending[O constraints.Ordered](t T, slice []O, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.Ascending(slice))
+	invoke(t, assertions.Ascending(slice), scripts...)
 }
 
 // AscendingFunc asserts slice[n] is less than slice[n+1] for each element n using the less comparator.
-func AscendingFunc[A any](t T, slice []A, less func(A, A) bool) {
+func AscendingFunc[A any](t T, slice []A, less func(A, A) bool, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.AscendingFunc(slice, less))
+	invoke(t, assertions.AscendingFunc(slice, less), scripts...)
 }
 
 // AscendingLess asserts slice[n].Less(slice[n+1]) for each element n.
-func AscendingLess[L interfaces.LessFunc[L]](t T, slice []L) {
+func AscendingLess[L interfaces.LessFunc[L]](t T, slice []L, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.AscendingLess(slice))
+	invoke(t, assertions.AscendingLess(slice), scripts...)
 }
 
 // Descending asserts slice[n] >= slice[n+1] for each element n.
-func Descending[O constraints.Ordered](t T, slice []O) {
+func Descending[O constraints.Ordered](t T, slice []O, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.Descending(slice))
+	invoke(t, assertions.Descending(slice), scripts...)
 }
 
 // DescendingFunc asserts slice[n+1] is less than slice[n] for each element n using the less comparator.
-func DescendingFunc[A any](t T, slice []A, less func(A, A) bool) {
+func DescendingFunc[A any](t T, slice []A, less func(A, A) bool, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.DescendingFunc(slice, less))
+	invoke(t, assertions.DescendingFunc(slice, less), scripts...)
 }
 
 // DescendingLess asserts slice[n+1].Less(slice[n]) for each element n.
-func DescendingLess[L interfaces.LessFunc[L]](t T, slice []L) {
+func DescendingLess[L interfaces.LessFunc[L]](t T, slice []L, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.DescendingLess(slice))
+	invoke(t, assertions.DescendingLess(slice), scripts...)
 }
 
 // InDelta asserts a and b are within delta of each other.
-func InDelta[N interfaces.Number](t T, a, b, delta N) {
+func InDelta[N interfaces.Number](t T, a, b, delta N, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.InDelta(a, b, delta))
+	invoke(t, assertions.InDelta(a, b, delta), scripts...)
 }
 
 // InDeltaSlice asserts each element a[n] is within delta of b[n].
-func InDeltaSlice[N interfaces.Number](t T, a, b []N, delta N) {
+func InDeltaSlice[N interfaces.Number](t T, a, b []N, delta N, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.InDeltaSlice(a, b, delta))
+	invoke(t, assertions.InDeltaSlice(a, b, delta), scripts...)
 }
 
 // MapEq asserts maps a and b contain the same key/value pairs, using
 // cmp.Equal function to compare values.
-func MapEq[M1, M2 interfaces.Map[K, V], K comparable, V any](t T, a M1, b M2) {
+func MapEq[M1, M2 interfaces.Map[K, V], K comparable, V any](t T, a M1, b M2, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.MapEq[M1, M2, K, V](a, b))
+	invoke(t, assertions.MapEq[M1, M2, K, V](a, b), scripts...)
 }
 
 // MapEqFunc asserts maps a and b contain the same key/value pairs, using eq to
 // compare values.
-func MapEqFunc[M1, M2 interfaces.Map[K, V], K comparable, V any](t T, a M1, b M2, eq func(V, V) bool) {
+func MapEqFunc[M1, M2 interfaces.Map[K, V], K comparable, V any](t T, a M1, b M2, eq func(V, V) bool, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.MapEqFunc[M1, M2, K, V](a, b, eq))
+	invoke(t, assertions.MapEqFunc[M1, M2, K, V](a, b, eq), scripts...)
 }
 
 // MapEquals asserts maps a and b contain the same key/value pairs, using Equals
 // method to compare values
-func MapEquals[M interfaces.MapEqualsFunc[K, V], K comparable, V interfaces.EqualsFunc[V]](t T, a, b M) {
+func MapEquals[M interfaces.MapEqualsFunc[K, V], K comparable, V interfaces.EqualsFunc[V]](t T, a, b M, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.MapEquals[M, K, V](a, b))
+	invoke(t, assertions.MapEquals[M, K, V](a, b), scripts...)
 }
 
 // MapLen asserts map is of size n.
-func MapLen[M ~map[K]V, K comparable, V any](t T, n int, m M) {
+func MapLen[M ~map[K]V, K comparable, V any](t T, n int, m M, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.MapLen[M, K, V](n, m))
+	invoke(t, assertions.MapLen[M, K, V](n, m), scripts...)
 }
 
 // MapEmpty asserts map is empty.
-func MapEmpty[M ~map[K]V, K comparable, V any](t T, m M) {
+func MapEmpty[M ~map[K]V, K comparable, V any](t T, m M, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.MapEmpty[M, K, V](m))
+	invoke(t, assertions.MapEmpty[M, K, V](m), scripts...)
 }
 
 // MapContainsKeys asserts m contains each key in keys.
-func MapContainsKeys[M ~map[K]V, K comparable, V any](t T, m M, keys []K) {
+func MapContainsKeys[M ~map[K]V, K comparable, V any](t T, m M, keys []K, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.MapContainsKeys[M, K, V](m, keys))
+	invoke(t, assertions.MapContainsKeys[M, K, V](m, keys), scripts...)
 }
 
 // MapContainsValues asserts m contains each value in values.
-func MapContainsValues[M ~map[K]V, K comparable, V any](t T, m M, values []V) {
+func MapContainsValues[M ~map[K]V, K comparable, V any](t T, m M, values []V, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.MapContainsValues[M, K, V](m, values))
+	invoke(t, assertions.MapContainsValues[M, K, V](m, values), scripts...)
 }
 
 // MapContainsValuesFunc asserts m contains each value in values using the eq function.
-func MapContainsValuesFunc[M ~map[K]V, K comparable, V any](t T, m M, values []V, eq func(V, V) bool) {
+func MapContainsValuesFunc[M ~map[K]V, K comparable, V any](t T, m M, values []V, eq func(V, V) bool, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.MapContainsValuesFunc[M, K, V](m, values, eq))
+	invoke(t, assertions.MapContainsValuesFunc[M, K, V](m, values, eq), scripts...)
 }
 
-func MapContainsValuesEquals[M ~map[K]V, K comparable, V interfaces.EqualsFunc[V]](t T, m M, values []V) {
+func MapContainsValuesEquals[M ~map[K]V, K comparable, V interfaces.EqualsFunc[V]](t T, m M, values []V, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.MapContainsValuesEquals[M, K, V](m, values))
+	invoke(t, assertions.MapContainsValuesEquals[M, K, V](m, values), scripts...)
 }
 
 // FileExists asserts file exists on system.
@@ -352,9 +352,9 @@ func MapContainsValuesEquals[M ~map[K]V, K comparable, V interfaces.EqualsFunc[V
 // Often os.DirFS is used to interact with the the host filesystem.
 // Example,
 // FileExists(t, os.DirFS("/etc"), "hosts")
-func FileExists(t T, system fs.FS, file string) {
+func FileExists(t T, system fs.FS, file string, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.FileExists(system, file))
+	invoke(t, assertions.FileExists(system, file), scripts...)
 }
 
 // FileNotExists asserts file does not exist on system.
@@ -362,9 +362,9 @@ func FileExists(t T, system fs.FS, file string) {
 // Often os.DirFS is used to interact with the host filesystem.
 // Example,
 // FileNotExist(t, os.DirFS("/bin"), "exploit.exe")
-func FileNotExists(t T, system fs.FS, file string) {
+func FileNotExists(t T, system fs.FS, file string, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.FileNotExists(system, file))
+	invoke(t, assertions.FileNotExists(system, file), scripts...)
 }
 
 // DirExists asserts directory exists on system.
@@ -372,9 +372,9 @@ func FileNotExists(t T, system fs.FS, file string) {
 // Often os.DirFS is used to interact with the host filesystem.
 // Example,
 // DirExists(t, os.DirFS("/usr/local"), "bin")
-func DirExists(t T, system fs.FS, directory string) {
+func DirExists(t T, system fs.FS, directory string, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.DirExists(system, directory))
+	invoke(t, assertions.DirExists(system, directory), scripts...)
 }
 
 // DirNotExists asserts directory does not exist on system.
@@ -382,9 +382,9 @@ func DirExists(t T, system fs.FS, directory string) {
 // Often os.DirFS is used to interact with the host filesystem.
 // Example,
 // DirNotExists(t, os.DirFS("/tmp"), "scratch")
-func DirNotExists(t T, system fs.FS, directory string) {
+func DirNotExists(t T, system fs.FS, directory string, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.DirNotExists(system, directory))
+	invoke(t, assertions.DirNotExists(system, directory), scripts...)
 }
 
 // FileMode asserts the file or directory at path has exactly
@@ -393,9 +393,9 @@ func DirNotExists(t T, system fs.FS, directory string) {
 // Often os.DirFS is used to interact with the host filesystem.
 // Example,
 // FileMode(t, os.DirFS("/bin"), "find", 0655)
-func FileMode(t T, system fs.FS, path string, permissions fs.FileMode) {
+func FileMode(t T, system fs.FS, path string, permissions fs.FileMode, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.FileMode(system, path, permissions))
+	invoke(t, assertions.FileMode(system, path, permissions), scripts...)
 }
 
 // FileContains asserts the file contains content as a substring.
@@ -403,19 +403,19 @@ func FileMode(t T, system fs.FS, path string, permissions fs.FileMode) {
 // Often os.DirFS is used to interact with the host filesystem.
 // Example,
 // FileContains(t, os.DirFS("/etc"), "hosts", "localhost")
-func FileContains(t T, system fs.FS, file, content string) {
+func FileContains(t T, system fs.FS, file, content string, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.FileContains(system, file, content))
+	invoke(t, assertions.FileContains(system, file, content), scripts...)
 }
 
 // FilePathValid asserts path is a valid file path.
-func FilePathValid(t T, path string) {
+func FilePathValid(t T, path string, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.FilePathValid(path))
+	invoke(t, assertions.FilePathValid(path), scripts...)
 }
 
 // RegexMatch asserts regular expression re matches string s.
-func RegexMatch(t T, re *regexp.Regexp, s string) {
+func RegexMatch(t T, re *regexp.Regexp, s string, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.RegexMatch(re, s))
+	invoke(t, assertions.RegexMatch(re, s), scripts...)
 }

--- a/must/must_test.go
+++ b/must/must_test.go
@@ -22,6 +22,13 @@ func TestNil(t *testing.T) {
 	Nil(tc, map[string]int{"foo": 1})
 }
 
+func TestNil_PS(t *testing.T) {
+	tc := newCapture(t)
+	t.Cleanup(tc.post)
+
+	Nil(tc, 42, tc.PS("nil"))
+}
+
 func TestNotNil(t *testing.T) {
 	tc := newCase(t, `expected to not be nil; is nil`)
 	t.Cleanup(tc.assert)
@@ -34,11 +41,25 @@ func TestNotNil(t *testing.T) {
 	NotNil(tc, m)
 }
 
+func TestNotNil_PS(t *testing.T) {
+	tc := newCapture(t)
+	t.Cleanup(tc.post)
+
+	NotNil(tc, nil, tc.PS("not nil"))
+}
+
 func TestTrue(t *testing.T) {
 	tc := newCase(t, `expected condition to be true; is false`)
 	t.Cleanup(tc.assert)
 
 	True(tc, false)
+}
+
+func TestTrue_PS(t *testing.T) {
+	tc := newCapture(t)
+	t.Cleanup(tc.post)
+
+	True(tc, false, tc.PS("true"))
 }
 
 func TestFalse(t *testing.T) {
@@ -48,11 +69,25 @@ func TestFalse(t *testing.T) {
 	False(tc, true)
 }
 
+func TestFalse_PS(t *testing.T) {
+	tc := newCapture(t)
+	t.Cleanup(tc.post)
+
+	False(tc, true, tc.PS("false"))
+}
+
 func TestUnreachable(t *testing.T) {
 	tc := newCase(t, `expected not to execute this code path`)
 	t.Cleanup(tc.assert)
 
 	Unreachable(tc)
+}
+
+func TestUnreachable_PS(t *testing.T) {
+	tc := newCapture(t)
+	t.Cleanup(tc.post)
+
+	Unreachable(tc, tc.PS("unreachable"))
 }
 
 func TestError(t *testing.T) {
@@ -62,11 +97,25 @@ func TestError(t *testing.T) {
 	Error(tc, nil)
 }
 
+func TestError_PS(t *testing.T) {
+	tc := newCapture(t)
+	t.Cleanup(tc.post)
+
+	Error(tc, nil, tc.PS("error"))
+}
+
 func TestEqError(t *testing.T) {
 	tc := newCase(t, `expected matching error strings`)
 	t.Cleanup(tc.assert)
 
 	EqError(tc, errors.New("oops"), "blah")
+}
+
+func TestEqError_PS(t *testing.T) {
+	tc := newCapture(t)
+	t.Cleanup(tc.post)
+
+	EqError(tc, errors.New("oops"), "blah", tc.PS("eq error"))
 }
 
 func TestEqError_nil(t *testing.T) {
@@ -85,6 +134,15 @@ func TestErrorIs(t *testing.T) {
 	ErrorIs(tc, e1, e2)
 }
 
+func TestErrorIs_PS(t *testing.T) {
+	tc := newCapture(t)
+	t.Cleanup(tc.post)
+
+	e1 := errors.New("foo")
+	e2 := errors.New("bar")
+	ErrorIs(tc, e1, e2, tc.PS("error is"))
+}
+
 func TestErrorIs_nil(t *testing.T) {
 	tc := newCase(t, `expected error; got nil`)
 	t.Cleanup(tc.assert)
@@ -98,6 +156,13 @@ func TestNoError(t *testing.T) {
 	t.Cleanup(tc.assert)
 
 	NoError(tc, errors.New("hello"))
+}
+
+func TestNoError_PS(t *testing.T) {
+	tc := newCapture(t)
+	t.Cleanup(tc.post)
+
+	NoError(tc, errors.New("hello"), tc.PS("no error"))
 }
 
 func TestEq(t *testing.T) {
@@ -143,12 +208,26 @@ func TestEq(t *testing.T) {
 	})
 }
 
+func TestEq_PS(t *testing.T) {
+	tc := newCapture(t)
+	t.Cleanup(tc.post)
+
+	Eq(tc, 1, 2, tc.PS("eq"))
+}
+
 func TestEqOp(t *testing.T) {
 	t.Run("number", func(t *testing.T) {
 		tc := newCase(t, `expected equality via ==`)
 		t.Cleanup(tc.assert)
 		EqOp(tc, "foo", "bar")
 	})
+}
+
+func TestEqOp_PS(t *testing.T) {
+	tc := newCapture(t)
+	t.Cleanup(tc.post)
+
+	EqOp(tc, "foo", "bar", tc.PS("eq op"))
 }
 
 func TestEqFunc(t *testing.T) {
@@ -163,6 +242,15 @@ func TestEqFunc(t *testing.T) {
 	})
 }
 
+func TestEqFunc_PS(t *testing.T) {
+	tc := newCapture(t)
+	t.Cleanup(tc.post)
+
+	EqFunc(tc, "hello", "world", func(a, b string) bool {
+		return a == b
+	}, tc.PS("eq func"))
+}
+
 func TestNotEq(t *testing.T) {
 	tc := newCase(t, `expected inequality via cmp.Equal function`)
 	t.Cleanup(tc.assert)
@@ -171,6 +259,13 @@ func TestNotEq(t *testing.T) {
 	b := &Person{ID: 100, Name: "Alice"}
 
 	NotEq(tc, a, b)
+}
+
+func TestNotEq_PS(t *testing.T) {
+	tc := newCapture(t)
+	t.Cleanup(tc.post)
+
+	NotEq(tc, 1, 1, tc.PS("not eq"))
 }
 
 func TestNotEqOp(t *testing.T) {
@@ -193,6 +288,13 @@ func TestNotEqOp(t *testing.T) {
 	})
 }
 
+func TestNotEqOp_PS(t *testing.T) {
+	tc := newCapture(t)
+	t.Cleanup(tc.post)
+
+	NotEqOp(tc, 1, 1, tc.PS("not eq op"))
+}
+
 func TestNotEqFunc(t *testing.T) {
 	tc := newCase(t, `expected inequality via 'eq' function`)
 	t.Cleanup(tc.assert)
@@ -205,11 +307,27 @@ func TestNotEqFunc(t *testing.T) {
 	})
 }
 
+func TestNotEqFunc_PS(t *testing.T) {
+	tc := newCapture(t)
+	t.Cleanup(tc.post)
+
+	NotEqFunc(tc, 1, 1, func(a, b int) bool {
+		return a == b
+	}, tc.PS("not eq func"))
+}
+
 func TestEqJSON(t *testing.T) {
 	tc := newCase(t, `expected equality via json marshalling`)
 	t.Cleanup(tc.assert)
 
 	EqJSON(tc, `{"a":1, "b":2}`, `{"b":2, "a":9}`)
+}
+
+func TestEqJSON_PS(t *testing.T) {
+	tc := newCapture(t)
+	t.Cleanup(tc.post)
+
+	EqJSON(tc, `"one"`, `"two"`, tc.PS("eq json"))
 }
 
 func TestEqSliceFunc(t *testing.T) {
@@ -245,6 +363,17 @@ func TestEqSliceFunc(t *testing.T) {
 	})
 }
 
+func TestEqSliceFunc_PS(t *testing.T) {
+	tc := newCapture(t)
+	t.Cleanup(tc.post)
+
+	a := []int{1, 2, 3}
+	b := []int{1, 2}
+	EqSliceFunc(tc, a, b, func(a, b int) bool {
+		return false
+	}, tc.PS("eq slice func"))
+}
+
 // Person implements the Equals and Less functions.
 type Person struct {
 	ID   int
@@ -269,6 +398,16 @@ func TestEquals(t *testing.T) {
 	Equals(tc, a, b)
 }
 
+func TestEquals_PS(t *testing.T) {
+	tc := newCapture(t)
+	t.Cleanup(tc.post)
+
+	a := &Person{ID: 100, Name: "Alice"}
+	b := &Person{ID: 150, Name: "Alice"}
+
+	Equals(tc, a, b, tc.PS("equals"))
+}
+
 func TestNotEquals(t *testing.T) {
 	tc := newCase(t, `expected inequality via .Equals method`)
 	t.Cleanup(tc.assert)
@@ -277,6 +416,16 @@ func TestNotEquals(t *testing.T) {
 	b := &Person{ID: 100, Name: "Alice"}
 
 	NotEquals(tc, a, b)
+}
+
+func TestNotEquals_PS(t *testing.T) {
+	tc := newCapture(t)
+	t.Cleanup(tc.post)
+
+	a := &Person{ID: 100, Name: "Alice"}
+	b := &Person{ID: 100, Name: "Alice"}
+
+	NotEquals(tc, a, b, tc.PS("not equals"))
 }
 
 func TestEqualsSlice(t *testing.T) {
@@ -325,18 +474,38 @@ func TestLesser(t *testing.T) {
 	Lesser(tc, a, b)
 }
 
+func TestLesser_PS(t *testing.T) {
+	tc := newCapture(t)
+	t.Cleanup(tc.post)
+
+	a := &Person{ID: 200, Name: "Alice"}
+	b := &Person{ID: 100, Name: "Bob"}
+
+	Lesser(tc, a, b, tc.PS("lesser"))
+}
+
 func TestEmptySlice(t *testing.T) {
 	tc := newCase(t, `expected slice to be empty`)
 	t.Cleanup(tc.assert)
-
 	EmptySlice(tc, []int{1, 2})
+}
+
+func TestEmptySlice_PS(t *testing.T) {
+	tc := newCapture(t)
+	t.Cleanup(tc.post)
+	EmptySlice(tc, []int{1, 2}, tc.PS("empty slice"))
 }
 
 func TestEmpty(t *testing.T) {
 	tc := newCase(t, `expected slice to be empty`)
 	t.Cleanup(tc.assert)
-
 	Empty(tc, []int{1, 2})
+}
+
+func TestEmpty_PS(t *testing.T) {
+	tc := newCapture(t)
+	t.Cleanup(tc.post)
+	Empty(tc, []int{1, 2}, tc.PS("empty"))
 }
 
 func TestLenSlice(t *testing.T) {
@@ -353,6 +522,12 @@ func TestLenSlice(t *testing.T) {
 	})
 }
 
+func TestLenSlice_PS(t *testing.T) {
+	tc := newCapture(t)
+	t.Cleanup(tc.post)
+	LenSlice(tc, 3, []int{1, 2}, tc.PS("len slice"))
+}
+
 func TestLen(t *testing.T) {
 	t.Run("strings", func(t *testing.T) {
 		tc := newCase(t, `expected slice to be different length`)
@@ -367,6 +542,12 @@ func TestLen(t *testing.T) {
 	})
 }
 
+func TestLen_PS(t *testing.T) {
+	tc := newCapture(t)
+	t.Cleanup(tc.post)
+	Len(tc, 3, []int{1, 2}, tc.PS("len"))
+}
+
 func TestContains(t *testing.T) {
 	t.Run("people", func(t *testing.T) {
 		tc := newCase(t, `expected slice to contain missing item via cmp.Equal function`)
@@ -378,6 +559,14 @@ func TestContains(t *testing.T) {
 		target := &Person{ID: 102, Name: "Carl"}
 		Contains(tc, a, target)
 	})
+}
+
+func TestContains_PS(t *testing.T) {
+	tc := newCapture(t)
+	t.Cleanup(tc.post)
+	s := []string{"one", "two", "three"}
+	target := "four"
+	Contains(tc, s, target, tc.PS("contains"))
 }
 
 func TestContainsOp(t *testing.T) {
@@ -865,4 +1054,33 @@ func TestRegexMatch(t *testing.T) {
 
 	re := regexp.MustCompile(`abc\d`)
 	RegexMatch(tc, re, "abcX")
+}
+
+func TestPS_Sprintf(t *testing.T) {
+	tc := newCapture(t)
+	Eq(tc, "a", "b", Sprintf("hello %s", "world"))
+}
+
+func TestPS_Sprint(t *testing.T) {
+	tc := newCapture(t)
+	Eq(tc, "a", "b", Sprint("hello", 42, "hi"))
+}
+
+func TestPS_Values(t *testing.T) {
+	tc := newCapture(t)
+	Eq(tc, "a", "b", Values("foo", "bar", 1, 2, "now", time.Now()))
+}
+
+func TestPS_Func(t *testing.T) {
+	tc := newCapture(t)
+	Eq(tc, "a", "b", Func(func() string {
+		return "hello"
+	}))
+}
+
+func TestEq_Combo(t *testing.T) {
+	tc := newCapture(t)
+	Eq(tc, "a", "b", Sprintf("this is a note"), Values("foo", "bar", "baz", 3), Func(func() string {
+		return "this is the result of a function"
+	}))
 }

--- a/must/scripts.go
+++ b/must/scripts.go
@@ -1,0 +1,86 @@
+// Code generated via scripts/generate.sh. DO NOT EDIT.
+
+package must
+
+import (
+	"fmt"
+	"strings"
+)
+
+func run(posts ...PostScript) string {
+	s := new(strings.Builder)
+	for _, post := range posts {
+		s.WriteString("↪ PostScript | ")
+		s.WriteString(post.Label())
+		s.WriteString(" ↷\n")
+		s.WriteString(post.Content())
+		s.WriteString("\n")
+	}
+	return s.String()
+}
+
+// A PostScript is used to annotate a test failure with additional information.
+//
+// Can be useful in large e2e style test cases, where adding additional context
+// beyond an assertion helps in debugging.
+type PostScript interface {
+	// Label should categorize what is in Content.
+	Label() string
+
+	// Content contains extra contextual information for debugging a test failure.
+	Content() string
+}
+
+type script struct {
+	label   string
+	content string
+}
+
+func (s *script) Label() string {
+	return strings.TrimSpace(s.label)
+}
+func (s *script) Content() string {
+	return "\t" + strings.TrimSpace(s.content)
+}
+
+// Sprintf appends a Sprintf-string as an annotation to the output of a test case failure.
+func Sprintf(msg string, args ...any) PostScript {
+	return &script{
+		label:   "annotation",
+		content: fmt.Sprintf(msg, args...),
+	}
+}
+
+// Sprint appends a Sprint-string as an annotation to the output of a test case failure.
+func Sprint(args ...any) PostScript {
+	return &script{
+		label:   "annotation",
+		content: strings.TrimSpace(fmt.Sprintln(args...)),
+	}
+}
+
+// Values adds formatted key-value mappings as an annotation to the output of a test case failure.
+func Values(values ...any) PostScript {
+	b := new(strings.Builder)
+	n := len(values)
+	for i := 0; i < n-1; i += 2 {
+		s := fmt.Sprintf("\t%#v => %#v\n", values[i], values[i+1])
+		b.WriteString(s)
+	}
+	if n%2 != 0 {
+		s := fmt.Sprintf("\t%v => <MISSING ARG>", values[n-1])
+		b.WriteString(s)
+	}
+	return &script{
+		label:   "mapping",
+		content: b.String(),
+	}
+}
+
+// Func adds the string produced by f as an annotation to the output of a test case failure.
+func Func(f func() string) PostScript {
+	return &script{
+		label:   "function",
+		content: f(),
+	}
+}

--- a/must/scripts_test.go
+++ b/must/scripts_test.go
@@ -1,0 +1,48 @@
+// Code generated via scripts/generate.sh. DO NOT EDIT.
+
+package must
+
+import "testing"
+
+func TestPostScript_Label(t *testing.T) {
+	var s PostScript = &script{label: "\nhello "}
+	if s.Label() != "hello" {
+		t.FailNow()
+	}
+}
+
+func TestPostScript_Content(t *testing.T) {
+	var s PostScript = &script{content: "\nhello "}
+	if s.Content() != "\thello" {
+		t.FailNow()
+	}
+}
+
+func TestPostScript_Sprintf(t *testing.T) {
+	ps := Sprintf("foo %s %d", "baz", 1)
+	result := run(ps)
+	exp := "↪ PostScript | annotation ↷\n\tfoo baz 1\n"
+	if result != exp {
+		t.Fatalf("exp %s, got %s", exp, result)
+	}
+}
+
+func TestPostScript_KV(t *testing.T) {
+	ps := Values("one", 1, "foo", "bar")
+	result := run(ps)
+	exp := "↪ PostScript | mapping ↷\n\t\"one\" => 1\n\t\"foo\" => \"bar\"\n"
+	if result != exp {
+		t.Fatalf("exp %s, got %s", exp, result)
+	}
+}
+
+func TestPostScript_Func(t *testing.T) {
+	ps := Func(func() string {
+		return "hello"
+	})
+	result := run(ps)
+	exp := "↪ PostScript | function ↷\n\thello\n"
+	if result != exp {
+		t.Fatalf("exp %s, got %s", exp, result)
+	}
+}

--- a/scripts.go
+++ b/scripts.go
@@ -1,0 +1,84 @@
+package test
+
+import (
+	"fmt"
+	"strings"
+)
+
+func run(posts ...PostScript) string {
+	s := new(strings.Builder)
+	for _, post := range posts {
+		s.WriteString("↪ PostScript | ")
+		s.WriteString(post.Label())
+		s.WriteString(" ↷\n")
+		s.WriteString(post.Content())
+		s.WriteString("\n")
+	}
+	return s.String()
+}
+
+// A PostScript is used to annotate a test failure with additional information.
+//
+// Can be useful in large e2e style test cases, where adding additional context
+// beyond an assertion helps in debugging.
+type PostScript interface {
+	// Label should categorize what is in Content.
+	Label() string
+
+	// Content contains extra contextual information for debugging a test failure.
+	Content() string
+}
+
+type script struct {
+	label   string
+	content string
+}
+
+func (s *script) Label() string {
+	return strings.TrimSpace(s.label)
+}
+func (s *script) Content() string {
+	return "\t" + strings.TrimSpace(s.content)
+}
+
+// Sprintf appends a Sprintf-string as an annotation to the output of a test case failure.
+func Sprintf(msg string, args ...any) PostScript {
+	return &script{
+		label:   "annotation",
+		content: fmt.Sprintf(msg, args...),
+	}
+}
+
+// Sprint appends a Sprint-string as an annotation to the output of a test case failure.
+func Sprint(args ...any) PostScript {
+	return &script{
+		label:   "annotation",
+		content: strings.TrimSpace(fmt.Sprintln(args...)),
+	}
+}
+
+// Values adds formatted key-value mappings as an annotation to the output of a test case failure.
+func Values(values ...any) PostScript {
+	b := new(strings.Builder)
+	n := len(values)
+	for i := 0; i < n-1; i += 2 {
+		s := fmt.Sprintf("\t%#v => %#v\n", values[i], values[i+1])
+		b.WriteString(s)
+	}
+	if n%2 != 0 {
+		s := fmt.Sprintf("\t%v => <MISSING ARG>", values[n-1])
+		b.WriteString(s)
+	}
+	return &script{
+		label:   "mapping",
+		content: b.String(),
+	}
+}
+
+// Func adds the string produced by f as an annotation to the output of a test case failure.
+func Func(f func() string) PostScript {
+	return &script{
+		label:   "function",
+		content: f(),
+	}
+}

--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -2,9 +2,15 @@
 
 set -euo pipefail
 
+cp scripts.go must/scripts.go
+cp scripts_test.go must/scripts_test.go
 cp test.go must/must.go
 cp test_test.go must/must_test.go
+sed -i "s|package test|package must|g" must/scripts.go
+sed -i "s|package test|package must|g" must/scripts_test.go
 sed -i "s|package test|package must|g" must/must.go
 sed -i "s|package test|package must|g" must/must_test.go
+sed -i -e "1s|^|// Code generated via scripts/generate.sh. DO NOT EDIT.\n\n|g" must/scripts.go
+sed -i -e "1s|^|// Code generated via scripts/generate.sh. DO NOT EDIT.\n\n|g" must/scripts_test.go
 sed -i -e "1s|^|// Code generated via scripts/generate.sh. DO NOT EDIT.\n\n|g" must/must.go
 sed -i -e "1s|^|// Code generated via scripts/generate.sh. DO NOT EDIT.\n\n|g" must/must_test.go

--- a/scripts_test.go
+++ b/scripts_test.go
@@ -1,0 +1,46 @@
+package test
+
+import "testing"
+
+func TestPostScript_Label(t *testing.T) {
+	var s PostScript = &script{label: "\nhello "}
+	if s.Label() != "hello" {
+		t.FailNow()
+	}
+}
+
+func TestPostScript_Content(t *testing.T) {
+	var s PostScript = &script{content: "\nhello "}
+	if s.Content() != "\thello" {
+		t.FailNow()
+	}
+}
+
+func TestPostScript_Sprintf(t *testing.T) {
+	ps := Sprintf("foo %s %d", "baz", 1)
+	result := run(ps)
+	exp := "↪ PostScript | annotation ↷\n\tfoo baz 1\n"
+	if result != exp {
+		t.Fatalf("exp %s, got %s", exp, result)
+	}
+}
+
+func TestPostScript_KV(t *testing.T) {
+	ps := Values("one", 1, "foo", "bar")
+	result := run(ps)
+	exp := "↪ PostScript | mapping ↷\n\t\"one\" => 1\n\t\"foo\" => \"bar\"\n"
+	if result != exp {
+		t.Fatalf("exp %s, got %s", exp, result)
+	}
+}
+
+func TestPostScript_Func(t *testing.T) {
+	ps := Func(func() string {
+		return "hello"
+	})
+	result := run(ps)
+	exp := "↪ PostScript | function ↷\n\thello\n"
+	if result != exp {
+		t.Fatalf("exp %s, got %s", exp, result)
+	}
+}

--- a/test.go
+++ b/test.go
@@ -10,339 +10,339 @@ import (
 )
 
 // Nil asserts a is nil.
-func Nil(t T, a any) {
+func Nil(t T, a any, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.Nil(a))
+	invoke(t, assertions.Nil(a), scripts...)
 }
 
 // NotNil asserts a is not nil.
-func NotNil(t T, a any) {
+func NotNil(t T, a any, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.NotNil(a))
+	invoke(t, assertions.NotNil(a), scripts...)
 }
 
 // True asserts that condition is true.
-func True(t T, condition bool) {
+func True(t T, condition bool, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.True(condition))
+	invoke(t, assertions.True(condition), scripts...)
 }
 
 // False asserts condition is false.
-func False(t T, condition bool) {
+func False(t T, condition bool, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.False(condition))
+	invoke(t, assertions.False(condition), scripts...)
 }
 
 // Unreachable asserts a code path is not executed.
-func Unreachable(t T) {
+func Unreachable(t T, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.Unreachable())
+	invoke(t, assertions.Unreachable(), scripts...)
 }
 
 // Error asserts err is a non-nil error.
-func Error(t T, err error) {
+func Error(t T, err error, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.Error(err))
+	invoke(t, assertions.Error(err), scripts...)
 }
 
 // EqError asserts err contains message msg.
-func EqError(t T, err error, msg string) {
+func EqError(t T, err error, msg string, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.EqError(err, msg))
+	invoke(t, assertions.EqError(err, msg), scripts...)
 }
 
 // ErrorIs asserts err
-func ErrorIs(t T, err error, target error) {
+func ErrorIs(t T, err error, target error, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.ErrorIs(err, target))
+	invoke(t, assertions.ErrorIs(err, target), scripts...)
 }
 
 // NoError asserts err is a nil error.
-func NoError(t T, err error) {
+func NoError(t T, err error, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.NoError(err))
+	invoke(t, assertions.NoError(err), scripts...)
 }
 
 // Eq asserts a and b are equal using cmp.Equal.
-func Eq[A any](t T, a, b A) {
+func Eq[A any](t T, a, b A, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.Eq(a, b))
+	invoke(t, assertions.Eq(a, b), scripts...)
 }
 
 // EqOp asserts a == b.
-func EqOp[C comparable](t T, a, b C) {
+func EqOp[C comparable](t T, a, b C, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.EqOp(a, b))
+	invoke(t, assertions.EqOp(a, b), scripts...)
 }
 
 // EqFunc asserts a and b are equal using eq.
-func EqFunc[A any](t T, a, b A, eq func(a, b A) bool) {
+func EqFunc[A any](t T, a, b A, eq func(a, b A) bool, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.EqFunc(a, b, eq))
+	invoke(t, assertions.EqFunc(a, b, eq), scripts...)
 }
 
 // NotEq asserts a and b are not equal using cmp.Equal.
-func NotEq[A any](t T, a, b A) {
+func NotEq[A any](t T, a, b A, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.NotEq(a, b))
+	invoke(t, assertions.NotEq(a, b), scripts...)
 }
 
 // NotEqOp asserts a != b.
-func NotEqOp[C comparable](t T, a, b C) {
+func NotEqOp[C comparable](t T, a, b C, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.NotEqOp(a, b))
+	invoke(t, assertions.NotEqOp(a, b), scripts...)
 }
 
 // NotEqFunc asserts a and b are not equal using eq.
-func NotEqFunc[A any](t T, a, b A, eq func(a, b A) bool) {
+func NotEqFunc[A any](t T, a, b A, eq func(a, b A) bool, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.NotEqFunc(a, b, eq))
+	invoke(t, assertions.NotEqFunc(a, b, eq), scripts...)
 }
 
 // EqJSON asserts a and b are equivalent JSON.
-func EqJSON(t T, a, b string) {
+func EqJSON(t T, a, b string, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.EqJSON(a, b))
+	invoke(t, assertions.EqJSON(a, b), scripts...)
 }
 
 // EqSliceFunc asserts elements of a and b are the same using eq.
-func EqSliceFunc[A any](t T, a, b []A, eq func(a, b A) bool) {
+func EqSliceFunc[A any](t T, a, b []A, eq func(a, b A) bool, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.EqSliceFunc(a, b, eq))
+	invoke(t, assertions.EqSliceFunc(a, b, eq), scripts...)
 }
 
 // Equals asserts a.Equals(b).
-func Equals[E interfaces.EqualsFunc[E]](t T, a, b E) {
+func Equals[E interfaces.EqualsFunc[E]](t T, a, b E, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.Equals(a, b))
+	invoke(t, assertions.Equals(a, b), scripts...)
 }
 
 // NotEquals asserts !a.Equals(b).
-func NotEquals[E interfaces.EqualsFunc[E]](t T, a, b E) {
+func NotEquals[E interfaces.EqualsFunc[E]](t T, a, b E, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.NotEquals(a, b))
+	invoke(t, assertions.NotEquals(a, b), scripts...)
 }
 
 // EqualsSlice asserts a[n].Equals(b[n]) for each element n in slices a and b.
-func EqualsSlice[E interfaces.EqualsFunc[E]](t T, a, b []E) {
+func EqualsSlice[E interfaces.EqualsFunc[E]](t T, a, b []E, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.EqualsSlice(a, b))
+	invoke(t, assertions.EqualsSlice(a, b), scripts...)
 }
 
 // Lesser asserts a.Less(b).
-func Lesser[L interfaces.LessFunc[L]](t T, a, b L) {
+func Lesser[L interfaces.LessFunc[L]](t T, a, b L, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.Lesser(a, b))
+	invoke(t, assertions.Lesser(a, b), scripts...)
 }
 
 // EmptySlice asserts slice is empty.
-func EmptySlice[A any](t T, slice []A) {
+func EmptySlice[A any](t T, slice []A, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.EmptySlice(slice))
+	invoke(t, assertions.EmptySlice(slice), scripts...)
 }
 
 // Empty asserts slice is empty.
 //
 // Convenience function for EmptySlice.
-func Empty[A any](t T, slice []A) {
+func Empty[A any](t T, slice []A, scripts ...PostScript) {
 	t.Helper()
-	EmptySlice(t, slice)
+	EmptySlice(t, slice, scripts...)
 }
 
 // LenSlice asserts slice is of length n.
-func LenSlice[A any](t T, n int, slice []A) {
+func LenSlice[A any](t T, n int, slice []A, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.LenSlice(n, slice))
+	invoke(t, assertions.LenSlice(n, slice), scripts...)
 }
 
 // Len asserts slice is of length n.
 //
 // Convenience function for LenSlice.
-func Len[A any](t T, n int, slice []A) {
+func Len[A any](t T, n int, slice []A, scripts ...PostScript) {
 	t.Helper()
-	LenSlice(t, n, slice)
+	invoke(t, assertions.LenSlice(n, slice), scripts...)
 }
 
 // Contains asserts item exists in slice using cmp.Equal function.
-func Contains[A any](t T, slice []A, item A) {
+func Contains[A any](t T, slice []A, item A, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.Contains(slice, item))
+	invoke(t, assertions.Contains(slice, item), scripts...)
 }
 
 // ContainsOp asserts item exists in slice using == operator.
-func ContainsOp[C comparable](t T, slice []C, item C) {
+func ContainsOp[C comparable](t T, slice []C, item C, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.ContainsOp(slice, item))
+	invoke(t, assertions.ContainsOp(slice, item), scripts...)
 }
 
 // ContainsFunc asserts item exists in slice, using eq to compare elements.
-func ContainsFunc[A any](t T, slice []A, item A, eq func(a, b A) bool) {
+func ContainsFunc[A any](t T, slice []A, item A, eq func(a, b A) bool, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.ContainsFunc(slice, item, eq))
+	invoke(t, assertions.ContainsFunc(slice, item, eq), scripts...)
 }
 
 // ContainsEquals asserts item exists in slice, using Equals to compare elements.
-func ContainsEquals[E interfaces.EqualsFunc[E]](t T, slice []E, item E) {
+func ContainsEquals[E interfaces.EqualsFunc[E]](t T, slice []E, item E, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.ContainsEquals(slice, item))
+	invoke(t, assertions.ContainsEquals(slice, item), scripts...)
 }
 
 // ContainsString asserts s contains sub.
-func ContainsString(t T, s, sub string) {
+func ContainsString(t T, s, sub string, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.ContainsString(s, sub))
+	invoke(t, assertions.ContainsString(s, sub), scripts...)
 }
 
 // Positive asserts n > 0.
-func Positive[N interfaces.Number](t T, n N) {
+func Positive[N interfaces.Number](t T, n N, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.Positive(n))
+	invoke(t, assertions.Positive(n), scripts...)
 }
 
 // Negative asserts n < 0.
-func Negative[N interfaces.Number](t T, n N) {
+func Negative[N interfaces.Number](t T, n N, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.Negative(n))
+	invoke(t, assertions.Negative(n), scripts...)
 }
 
 // Zero asserts n == 0.
-func Zero[N interfaces.Number](t T, n N) {
+func Zero[N interfaces.Number](t T, n N, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.Zero(n))
+	invoke(t, assertions.Zero(n), scripts...)
 }
 
 // NonZero asserts n != 0.
-func NonZero[N interfaces.Number](t T, n N) {
+func NonZero[N interfaces.Number](t T, n N, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.NonZero(n))
+	invoke(t, assertions.NonZero(n), scripts...)
 }
 
 // Less asserts a < b.
-func Less[O constraints.Ordered](t T, a, b O) {
+func Less[O constraints.Ordered](t T, a, b O, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.Less(a, b))
+	invoke(t, assertions.Less(a, b), scripts...)
 }
 
 // LessEq asserts a <= b.
-func LessEq[O constraints.Ordered](t T, a, b O) {
+func LessEq[O constraints.Ordered](t T, a, b O, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.LessEq(a, b))
+	invoke(t, assertions.LessEq(a, b), scripts...)
 }
 
 // Greater asserts a > b.
-func Greater[O constraints.Ordered](t T, a, b O) {
+func Greater[O constraints.Ordered](t T, a, b O, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.Greater(a, b))
+	invoke(t, assertions.Greater(a, b), scripts...)
 }
 
 // GreaterEq asserts a >= b.
-func GreaterEq[O constraints.Ordered](t T, a, b O) {
+func GreaterEq[O constraints.Ordered](t T, a, b O, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.GreaterEq(a, b))
+	invoke(t, assertions.GreaterEq(a, b), scripts...)
 }
 
 // Ascending asserts slice[n] <= slice[n+1] for each element n.
-func Ascending[O constraints.Ordered](t T, slice []O) {
+func Ascending[O constraints.Ordered](t T, slice []O, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.Ascending(slice))
+	invoke(t, assertions.Ascending(slice), scripts...)
 }
 
 // AscendingFunc asserts slice[n] is less than slice[n+1] for each element n using the less comparator.
-func AscendingFunc[A any](t T, slice []A, less func(A, A) bool) {
+func AscendingFunc[A any](t T, slice []A, less func(A, A) bool, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.AscendingFunc(slice, less))
+	invoke(t, assertions.AscendingFunc(slice, less), scripts...)
 }
 
 // AscendingLess asserts slice[n].Less(slice[n+1]) for each element n.
-func AscendingLess[L interfaces.LessFunc[L]](t T, slice []L) {
+func AscendingLess[L interfaces.LessFunc[L]](t T, slice []L, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.AscendingLess(slice))
+	invoke(t, assertions.AscendingLess(slice), scripts...)
 }
 
 // Descending asserts slice[n] >= slice[n+1] for each element n.
-func Descending[O constraints.Ordered](t T, slice []O) {
+func Descending[O constraints.Ordered](t T, slice []O, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.Descending(slice))
+	invoke(t, assertions.Descending(slice), scripts...)
 }
 
 // DescendingFunc asserts slice[n+1] is less than slice[n] for each element n using the less comparator.
-func DescendingFunc[A any](t T, slice []A, less func(A, A) bool) {
+func DescendingFunc[A any](t T, slice []A, less func(A, A) bool, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.DescendingFunc(slice, less))
+	invoke(t, assertions.DescendingFunc(slice, less), scripts...)
 }
 
 // DescendingLess asserts slice[n+1].Less(slice[n]) for each element n.
-func DescendingLess[L interfaces.LessFunc[L]](t T, slice []L) {
+func DescendingLess[L interfaces.LessFunc[L]](t T, slice []L, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.DescendingLess(slice))
+	invoke(t, assertions.DescendingLess(slice), scripts...)
 }
 
 // InDelta asserts a and b are within delta of each other.
-func InDelta[N interfaces.Number](t T, a, b, delta N) {
+func InDelta[N interfaces.Number](t T, a, b, delta N, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.InDelta(a, b, delta))
+	invoke(t, assertions.InDelta(a, b, delta), scripts...)
 }
 
 // InDeltaSlice asserts each element a[n] is within delta of b[n].
-func InDeltaSlice[N interfaces.Number](t T, a, b []N, delta N) {
+func InDeltaSlice[N interfaces.Number](t T, a, b []N, delta N, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.InDeltaSlice(a, b, delta))
+	invoke(t, assertions.InDeltaSlice(a, b, delta), scripts...)
 }
 
 // MapEq asserts maps a and b contain the same key/value pairs, using
 // cmp.Equal function to compare values.
-func MapEq[M1, M2 interfaces.Map[K, V], K comparable, V any](t T, a M1, b M2) {
+func MapEq[M1, M2 interfaces.Map[K, V], K comparable, V any](t T, a M1, b M2, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.MapEq[M1, M2, K, V](a, b))
+	invoke(t, assertions.MapEq[M1, M2, K, V](a, b), scripts...)
 }
 
 // MapEqFunc asserts maps a and b contain the same key/value pairs, using eq to
 // compare values.
-func MapEqFunc[M1, M2 interfaces.Map[K, V], K comparable, V any](t T, a M1, b M2, eq func(V, V) bool) {
+func MapEqFunc[M1, M2 interfaces.Map[K, V], K comparable, V any](t T, a M1, b M2, eq func(V, V) bool, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.MapEqFunc[M1, M2, K, V](a, b, eq))
+	invoke(t, assertions.MapEqFunc[M1, M2, K, V](a, b, eq), scripts...)
 }
 
 // MapEquals asserts maps a and b contain the same key/value pairs, using Equals
 // method to compare values
-func MapEquals[M interfaces.MapEqualsFunc[K, V], K comparable, V interfaces.EqualsFunc[V]](t T, a, b M) {
+func MapEquals[M interfaces.MapEqualsFunc[K, V], K comparable, V interfaces.EqualsFunc[V]](t T, a, b M, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.MapEquals[M, K, V](a, b))
+	invoke(t, assertions.MapEquals[M, K, V](a, b), scripts...)
 }
 
 // MapLen asserts map is of size n.
-func MapLen[M ~map[K]V, K comparable, V any](t T, n int, m M) {
+func MapLen[M ~map[K]V, K comparable, V any](t T, n int, m M, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.MapLen[M, K, V](n, m))
+	invoke(t, assertions.MapLen[M, K, V](n, m), scripts...)
 }
 
 // MapEmpty asserts map is empty.
-func MapEmpty[M ~map[K]V, K comparable, V any](t T, m M) {
+func MapEmpty[M ~map[K]V, K comparable, V any](t T, m M, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.MapEmpty[M, K, V](m))
+	invoke(t, assertions.MapEmpty[M, K, V](m), scripts...)
 }
 
 // MapContainsKeys asserts m contains each key in keys.
-func MapContainsKeys[M ~map[K]V, K comparable, V any](t T, m M, keys []K) {
+func MapContainsKeys[M ~map[K]V, K comparable, V any](t T, m M, keys []K, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.MapContainsKeys[M, K, V](m, keys))
+	invoke(t, assertions.MapContainsKeys[M, K, V](m, keys), scripts...)
 }
 
 // MapContainsValues asserts m contains each value in values.
-func MapContainsValues[M ~map[K]V, K comparable, V any](t T, m M, values []V) {
+func MapContainsValues[M ~map[K]V, K comparable, V any](t T, m M, values []V, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.MapContainsValues[M, K, V](m, values))
+	invoke(t, assertions.MapContainsValues[M, K, V](m, values), scripts...)
 }
 
 // MapContainsValuesFunc asserts m contains each value in values using the eq function.
-func MapContainsValuesFunc[M ~map[K]V, K comparable, V any](t T, m M, values []V, eq func(V, V) bool) {
+func MapContainsValuesFunc[M ~map[K]V, K comparable, V any](t T, m M, values []V, eq func(V, V) bool, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.MapContainsValuesFunc[M, K, V](m, values, eq))
+	invoke(t, assertions.MapContainsValuesFunc[M, K, V](m, values, eq), scripts...)
 }
 
-func MapContainsValuesEquals[M ~map[K]V, K comparable, V interfaces.EqualsFunc[V]](t T, m M, values []V) {
+func MapContainsValuesEquals[M ~map[K]V, K comparable, V interfaces.EqualsFunc[V]](t T, m M, values []V, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.MapContainsValuesEquals[M, K, V](m, values))
+	invoke(t, assertions.MapContainsValuesEquals[M, K, V](m, values), scripts...)
 }
 
 // FileExists asserts file exists on system.
@@ -350,9 +350,9 @@ func MapContainsValuesEquals[M ~map[K]V, K comparable, V interfaces.EqualsFunc[V
 // Often os.DirFS is used to interact with the the host filesystem.
 // Example,
 // FileExists(t, os.DirFS("/etc"), "hosts")
-func FileExists(t T, system fs.FS, file string) {
+func FileExists(t T, system fs.FS, file string, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.FileExists(system, file))
+	invoke(t, assertions.FileExists(system, file), scripts...)
 }
 
 // FileNotExists asserts file does not exist on system.
@@ -360,9 +360,9 @@ func FileExists(t T, system fs.FS, file string) {
 // Often os.DirFS is used to interact with the host filesystem.
 // Example,
 // FileNotExist(t, os.DirFS("/bin"), "exploit.exe")
-func FileNotExists(t T, system fs.FS, file string) {
+func FileNotExists(t T, system fs.FS, file string, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.FileNotExists(system, file))
+	invoke(t, assertions.FileNotExists(system, file), scripts...)
 }
 
 // DirExists asserts directory exists on system.
@@ -370,9 +370,9 @@ func FileNotExists(t T, system fs.FS, file string) {
 // Often os.DirFS is used to interact with the host filesystem.
 // Example,
 // DirExists(t, os.DirFS("/usr/local"), "bin")
-func DirExists(t T, system fs.FS, directory string) {
+func DirExists(t T, system fs.FS, directory string, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.DirExists(system, directory))
+	invoke(t, assertions.DirExists(system, directory), scripts...)
 }
 
 // DirNotExists asserts directory does not exist on system.
@@ -380,9 +380,9 @@ func DirExists(t T, system fs.FS, directory string) {
 // Often os.DirFS is used to interact with the host filesystem.
 // Example,
 // DirNotExists(t, os.DirFS("/tmp"), "scratch")
-func DirNotExists(t T, system fs.FS, directory string) {
+func DirNotExists(t T, system fs.FS, directory string, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.DirNotExists(system, directory))
+	invoke(t, assertions.DirNotExists(system, directory), scripts...)
 }
 
 // FileMode asserts the file or directory at path has exactly
@@ -391,9 +391,9 @@ func DirNotExists(t T, system fs.FS, directory string) {
 // Often os.DirFS is used to interact with the host filesystem.
 // Example,
 // FileMode(t, os.DirFS("/bin"), "find", 0655)
-func FileMode(t T, system fs.FS, path string, permissions fs.FileMode) {
+func FileMode(t T, system fs.FS, path string, permissions fs.FileMode, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.FileMode(system, path, permissions))
+	invoke(t, assertions.FileMode(system, path, permissions), scripts...)
 }
 
 // FileContains asserts the file contains content as a substring.
@@ -401,19 +401,19 @@ func FileMode(t T, system fs.FS, path string, permissions fs.FileMode) {
 // Often os.DirFS is used to interact with the host filesystem.
 // Example,
 // FileContains(t, os.DirFS("/etc"), "hosts", "localhost")
-func FileContains(t T, system fs.FS, file, content string) {
+func FileContains(t T, system fs.FS, file, content string, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.FileContains(system, file, content))
+	invoke(t, assertions.FileContains(system, file, content), scripts...)
 }
 
 // FilePathValid asserts path is a valid file path.
-func FilePathValid(t T, path string) {
+func FilePathValid(t T, path string, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.FilePathValid(path))
+	invoke(t, assertions.FilePathValid(path), scripts...)
 }
 
 // RegexMatch asserts regular expression re matches string s.
-func RegexMatch(t T, re *regexp.Regexp, s string) {
+func RegexMatch(t T, re *regexp.Regexp, s string, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.RegexMatch(re, s))
+	invoke(t, assertions.RegexMatch(re, s), scripts...)
 }

--- a/test_test.go
+++ b/test_test.go
@@ -20,6 +20,13 @@ func TestNil(t *testing.T) {
 	Nil(tc, map[string]int{"foo": 1})
 }
 
+func TestNil_PS(t *testing.T) {
+	tc := newCapture(t)
+	t.Cleanup(tc.post)
+
+	Nil(tc, 42, tc.PS("nil"))
+}
+
 func TestNotNil(t *testing.T) {
 	tc := newCase(t, `expected to not be nil; is nil`)
 	t.Cleanup(tc.assert)
@@ -32,11 +39,25 @@ func TestNotNil(t *testing.T) {
 	NotNil(tc, m)
 }
 
+func TestNotNil_PS(t *testing.T) {
+	tc := newCapture(t)
+	t.Cleanup(tc.post)
+
+	NotNil(tc, nil, tc.PS("not nil"))
+}
+
 func TestTrue(t *testing.T) {
 	tc := newCase(t, `expected condition to be true; is false`)
 	t.Cleanup(tc.assert)
 
 	True(tc, false)
+}
+
+func TestTrue_PS(t *testing.T) {
+	tc := newCapture(t)
+	t.Cleanup(tc.post)
+
+	True(tc, false, tc.PS("true"))
 }
 
 func TestFalse(t *testing.T) {
@@ -46,11 +67,25 @@ func TestFalse(t *testing.T) {
 	False(tc, true)
 }
 
+func TestFalse_PS(t *testing.T) {
+	tc := newCapture(t)
+	t.Cleanup(tc.post)
+
+	False(tc, true, tc.PS("false"))
+}
+
 func TestUnreachable(t *testing.T) {
 	tc := newCase(t, `expected not to execute this code path`)
 	t.Cleanup(tc.assert)
 
 	Unreachable(tc)
+}
+
+func TestUnreachable_PS(t *testing.T) {
+	tc := newCapture(t)
+	t.Cleanup(tc.post)
+
+	Unreachable(tc, tc.PS("unreachable"))
 }
 
 func TestError(t *testing.T) {
@@ -60,11 +95,25 @@ func TestError(t *testing.T) {
 	Error(tc, nil)
 }
 
+func TestError_PS(t *testing.T) {
+	tc := newCapture(t)
+	t.Cleanup(tc.post)
+
+	Error(tc, nil, tc.PS("error"))
+}
+
 func TestEqError(t *testing.T) {
 	tc := newCase(t, `expected matching error strings`)
 	t.Cleanup(tc.assert)
 
 	EqError(tc, errors.New("oops"), "blah")
+}
+
+func TestEqError_PS(t *testing.T) {
+	tc := newCapture(t)
+	t.Cleanup(tc.post)
+
+	EqError(tc, errors.New("oops"), "blah", tc.PS("eq error"))
 }
 
 func TestEqError_nil(t *testing.T) {
@@ -83,6 +132,15 @@ func TestErrorIs(t *testing.T) {
 	ErrorIs(tc, e1, e2)
 }
 
+func TestErrorIs_PS(t *testing.T) {
+	tc := newCapture(t)
+	t.Cleanup(tc.post)
+
+	e1 := errors.New("foo")
+	e2 := errors.New("bar")
+	ErrorIs(tc, e1, e2, tc.PS("error is"))
+}
+
 func TestErrorIs_nil(t *testing.T) {
 	tc := newCase(t, `expected error; got nil`)
 	t.Cleanup(tc.assert)
@@ -96,6 +154,13 @@ func TestNoError(t *testing.T) {
 	t.Cleanup(tc.assert)
 
 	NoError(tc, errors.New("hello"))
+}
+
+func TestNoError_PS(t *testing.T) {
+	tc := newCapture(t)
+	t.Cleanup(tc.post)
+
+	NoError(tc, errors.New("hello"), tc.PS("no error"))
 }
 
 func TestEq(t *testing.T) {
@@ -141,12 +206,26 @@ func TestEq(t *testing.T) {
 	})
 }
 
+func TestEq_PS(t *testing.T) {
+	tc := newCapture(t)
+	t.Cleanup(tc.post)
+
+	Eq(tc, 1, 2, tc.PS("eq"))
+}
+
 func TestEqOp(t *testing.T) {
 	t.Run("number", func(t *testing.T) {
 		tc := newCase(t, `expected equality via ==`)
 		t.Cleanup(tc.assert)
 		EqOp(tc, "foo", "bar")
 	})
+}
+
+func TestEqOp_PS(t *testing.T) {
+	tc := newCapture(t)
+	t.Cleanup(tc.post)
+
+	EqOp(tc, "foo", "bar", tc.PS("eq op"))
 }
 
 func TestEqFunc(t *testing.T) {
@@ -161,6 +240,15 @@ func TestEqFunc(t *testing.T) {
 	})
 }
 
+func TestEqFunc_PS(t *testing.T) {
+	tc := newCapture(t)
+	t.Cleanup(tc.post)
+
+	EqFunc(tc, "hello", "world", func(a, b string) bool {
+		return a == b
+	}, tc.PS("eq func"))
+}
+
 func TestNotEq(t *testing.T) {
 	tc := newCase(t, `expected inequality via cmp.Equal function`)
 	t.Cleanup(tc.assert)
@@ -169,6 +257,13 @@ func TestNotEq(t *testing.T) {
 	b := &Person{ID: 100, Name: "Alice"}
 
 	NotEq(tc, a, b)
+}
+
+func TestNotEq_PS(t *testing.T) {
+	tc := newCapture(t)
+	t.Cleanup(tc.post)
+
+	NotEq(tc, 1, 1, tc.PS("not eq"))
 }
 
 func TestNotEqOp(t *testing.T) {
@@ -191,6 +286,13 @@ func TestNotEqOp(t *testing.T) {
 	})
 }
 
+func TestNotEqOp_PS(t *testing.T) {
+	tc := newCapture(t)
+	t.Cleanup(tc.post)
+
+	NotEqOp(tc, 1, 1, tc.PS("not eq op"))
+}
+
 func TestNotEqFunc(t *testing.T) {
 	tc := newCase(t, `expected inequality via 'eq' function`)
 	t.Cleanup(tc.assert)
@@ -203,11 +305,27 @@ func TestNotEqFunc(t *testing.T) {
 	})
 }
 
+func TestNotEqFunc_PS(t *testing.T) {
+	tc := newCapture(t)
+	t.Cleanup(tc.post)
+
+	NotEqFunc(tc, 1, 1, func(a, b int) bool {
+		return a == b
+	}, tc.PS("not eq func"))
+}
+
 func TestEqJSON(t *testing.T) {
 	tc := newCase(t, `expected equality via json marshalling`)
 	t.Cleanup(tc.assert)
 
 	EqJSON(tc, `{"a":1, "b":2}`, `{"b":2, "a":9}`)
+}
+
+func TestEqJSON_PS(t *testing.T) {
+	tc := newCapture(t)
+	t.Cleanup(tc.post)
+
+	EqJSON(tc, `"one"`, `"two"`, tc.PS("eq json"))
 }
 
 func TestEqSliceFunc(t *testing.T) {
@@ -243,6 +361,17 @@ func TestEqSliceFunc(t *testing.T) {
 	})
 }
 
+func TestEqSliceFunc_PS(t *testing.T) {
+	tc := newCapture(t)
+	t.Cleanup(tc.post)
+
+	a := []int{1, 2, 3}
+	b := []int{1, 2}
+	EqSliceFunc(tc, a, b, func(a, b int) bool {
+		return false
+	}, tc.PS("eq slice func"))
+}
+
 // Person implements the Equals and Less functions.
 type Person struct {
 	ID   int
@@ -267,6 +396,16 @@ func TestEquals(t *testing.T) {
 	Equals(tc, a, b)
 }
 
+func TestEquals_PS(t *testing.T) {
+	tc := newCapture(t)
+	t.Cleanup(tc.post)
+
+	a := &Person{ID: 100, Name: "Alice"}
+	b := &Person{ID: 150, Name: "Alice"}
+
+	Equals(tc, a, b, tc.PS("equals"))
+}
+
 func TestNotEquals(t *testing.T) {
 	tc := newCase(t, `expected inequality via .Equals method`)
 	t.Cleanup(tc.assert)
@@ -275,6 +414,16 @@ func TestNotEquals(t *testing.T) {
 	b := &Person{ID: 100, Name: "Alice"}
 
 	NotEquals(tc, a, b)
+}
+
+func TestNotEquals_PS(t *testing.T) {
+	tc := newCapture(t)
+	t.Cleanup(tc.post)
+
+	a := &Person{ID: 100, Name: "Alice"}
+	b := &Person{ID: 100, Name: "Alice"}
+
+	NotEquals(tc, a, b, tc.PS("not equals"))
 }
 
 func TestEqualsSlice(t *testing.T) {
@@ -323,18 +472,38 @@ func TestLesser(t *testing.T) {
 	Lesser(tc, a, b)
 }
 
+func TestLesser_PS(t *testing.T) {
+	tc := newCapture(t)
+	t.Cleanup(tc.post)
+
+	a := &Person{ID: 200, Name: "Alice"}
+	b := &Person{ID: 100, Name: "Bob"}
+
+	Lesser(tc, a, b, tc.PS("lesser"))
+}
+
 func TestEmptySlice(t *testing.T) {
 	tc := newCase(t, `expected slice to be empty`)
 	t.Cleanup(tc.assert)
-
 	EmptySlice(tc, []int{1, 2})
+}
+
+func TestEmptySlice_PS(t *testing.T) {
+	tc := newCapture(t)
+	t.Cleanup(tc.post)
+	EmptySlice(tc, []int{1, 2}, tc.PS("empty slice"))
 }
 
 func TestEmpty(t *testing.T) {
 	tc := newCase(t, `expected slice to be empty`)
 	t.Cleanup(tc.assert)
-
 	Empty(tc, []int{1, 2})
+}
+
+func TestEmpty_PS(t *testing.T) {
+	tc := newCapture(t)
+	t.Cleanup(tc.post)
+	Empty(tc, []int{1, 2}, tc.PS("empty"))
 }
 
 func TestLenSlice(t *testing.T) {
@@ -351,6 +520,12 @@ func TestLenSlice(t *testing.T) {
 	})
 }
 
+func TestLenSlice_PS(t *testing.T) {
+	tc := newCapture(t)
+	t.Cleanup(tc.post)
+	LenSlice(tc, 3, []int{1, 2}, tc.PS("len slice"))
+}
+
 func TestLen(t *testing.T) {
 	t.Run("strings", func(t *testing.T) {
 		tc := newCase(t, `expected slice to be different length`)
@@ -365,6 +540,12 @@ func TestLen(t *testing.T) {
 	})
 }
 
+func TestLen_PS(t *testing.T) {
+	tc := newCapture(t)
+	t.Cleanup(tc.post)
+	Len(tc, 3, []int{1, 2}, tc.PS("len"))
+}
+
 func TestContains(t *testing.T) {
 	t.Run("people", func(t *testing.T) {
 		tc := newCase(t, `expected slice to contain missing item via cmp.Equal function`)
@@ -376,6 +557,14 @@ func TestContains(t *testing.T) {
 		target := &Person{ID: 102, Name: "Carl"}
 		Contains(tc, a, target)
 	})
+}
+
+func TestContains_PS(t *testing.T) {
+	tc := newCapture(t)
+	t.Cleanup(tc.post)
+	s := []string{"one", "two", "three"}
+	target := "four"
+	Contains(tc, s, target, tc.PS("contains"))
 }
 
 func TestContainsOp(t *testing.T) {
@@ -863,4 +1052,33 @@ func TestRegexMatch(t *testing.T) {
 
 	re := regexp.MustCompile(`abc\d`)
 	RegexMatch(tc, re, "abcX")
+}
+
+func TestPS_Sprintf(t *testing.T) {
+	tc := newCapture(t)
+	Eq(tc, "a", "b", Sprintf("hello %s", "world"))
+}
+
+func TestPS_Sprint(t *testing.T) {
+	tc := newCapture(t)
+	Eq(tc, "a", "b", Sprint("hello", 42, "hi"))
+}
+
+func TestPS_Values(t *testing.T) {
+	tc := newCapture(t)
+	Eq(tc, "a", "b", Values("foo", "bar", 1, 2, "now", time.Now()))
+}
+
+func TestPS_Func(t *testing.T) {
+	tc := newCapture(t)
+	Eq(tc, "a", "b", Func(func() string {
+		return "hello"
+	}))
+}
+
+func TestEq_Combo(t *testing.T) {
+	tc := newCapture(t)
+	Eq(tc, "a", "b", Sprintf("this is a note"), Values("foo", "bar", "baz", 3), Func(func() string {
+		return "this is the result of a function"
+	}))
 }


### PR DESCRIPTION
This PR adds `PostScript` variadic arguments to each assertion function,
enabling adding more context to test failures.

Examples

```golang
// Add a single Sprintf-string to the output of a failed test assertion.
must.Eq(t, exp, result, must.Note("some more context: %v", value))
```

```
keys_test.go:87: expected equality via cmp.Equal function
↪ Assertion | differential ↷
  int(
- 	1,
+ 	2,
  )
↪ PostScript | annotation ↷
 more context: hello
```

```golang
// Add a formatted key-value map to the output of a failed test assertion.
must.Eq(t, exp, result, must.Map(
  "one", 1,
  "two", 2,
  "fruit", "banana",
))
```

```
↪ Assertion | differential ↷
  int(
- 	1,
+ 	2,
  )
↪ PostScript | mapping ↷
 "one" => 1
 "two" => 2
 "fruit" => "banana"
```

```golang
// Add the output from a closure to the output of a failed test assertion.
must.Eq(t, exp, result, must.Func(func() string {
  // ... something interesting
  return s
})
```
```
keys_test.go:87: expected equality via cmp.Equal function
↪ Assertion | differential ↷
  int(
- 	1,
+ 	2,
  )
↪ PostScript | function ↷
 context from a function
```
