### PR TITLE
refactor: expectation always comes first

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,11 @@ There are two packages, `test` and `must`.
 
 ### Changes
 
-:warning: v0.4.0 contains breaking changes - Slice functions are renamed to be more consistent and to make room for interface based variants.
+:warning: v0.4.0 contains breaking changes
+
+ - Slice functions are renamed to be more consistent and to make room for interface based variants.
+ - Filesystem assertions now use OS by default, FS interface methods are renamed.
+ - Comparison assertions now have the expectation parameter first.
 
 ### Requirements
 

--- a/internal/assertions/assertions.go
+++ b/internal/assertions/assertions.go
@@ -165,60 +165,60 @@ func NoError(err error) (s string) {
 	return
 }
 
-func Eq[A any](expectation, value A) (s string) {
-	if !equal(expectation, value) {
+func Eq[A any](exp, val A) (s string) {
+	if !equal(exp, val) {
 		s = "expected equality via cmp.Equal function\n"
-		s += diff(expectation, value)
+		s += diff(exp, val)
 	}
 	return
 }
 
-func NotEq[A any](expectation, value A) (s string) {
-	if equal(expectation, value) {
+func NotEq[A any](exp, val A) (s string) {
+	if equal(exp, val) {
 		s = "expected inequality via cmp.Equal function\n"
 	}
 	return
 }
 
-func EqOp[C comparable](expectation, value C) (s string) {
-	if expectation != value {
+func EqOp[C comparable](exp, val C) (s string) {
+	if exp != val {
 		s = "expected equality via ==\n"
-		s += diff(expectation, value)
+		s += diff(exp, val)
 	}
 	return
 }
 
-func EqFunc[A any](expectation, value A, eq func(a, b A) bool) (s string) {
-	if !eq(expectation, value) {
+func EqFunc[A any](exp, val A, eq func(a, b A) bool) (s string) {
+	if !eq(exp, val) {
 		s = "expected equality via 'eq' function\n"
-		s += diff(expectation, value)
+		s += diff(exp, val)
 	}
 	return
 }
 
-func NotEqOp[C comparable](expectation, value C) (s string) {
-	if expectation == value {
+func NotEqOp[C comparable](exp, val C) (s string) {
+	if exp == val {
 		s = "expected inequality via !="
 	}
 	return
 }
 
-func NotEqFunc[A any](expectation, value A, eq func(a, b A) bool) (s string) {
-	if eq(expectation, value) {
+func NotEqFunc[A any](exp, val A, eq func(a, b A) bool) (s string) {
+	if eq(exp, val) {
 		s = "expected inequality via 'eq' function"
 	}
 	return
 }
 
-func EqJSON(expectation, value string) (s string) {
+func EqJSON(exp, val string) (s string) {
 	var expA, expB any
 
-	if err := json.Unmarshal([]byte(expectation), &expA); err != nil {
+	if err := json.Unmarshal([]byte(exp), &expA); err != nil {
 		s = fmt.Sprintf("failed to unmarshal first argument as json: %v", err)
 		return
 	}
 
-	if err := json.Unmarshal([]byte(value), &expB); err != nil {
+	if err := json.Unmarshal([]byte(val), &expB); err != nil {
 		s = fmt.Sprintf("failed to unmarshal second argument as json: %v", err)
 		return
 	}
@@ -234,20 +234,20 @@ func EqJSON(expectation, value string) (s string) {
 	return
 }
 
-func EqSliceFunc[A any](expectation, value []A, eq func(a, b A) bool) (s string) {
-	lenA, lenB := len(expectation), len(value)
+func EqSliceFunc[A any](exp, val []A, eq func(a, b A) bool) (s string) {
+	lenA, lenB := len(exp), len(val)
 
 	if lenA != lenB {
 		s = "expected slices of same length\n"
 		s += fmt.Sprintf("↪ len(exp): %d\n", lenA)
 		s += fmt.Sprintf("↪ len(val): %d\n", lenB)
-		s += diff(expectation, value)
+		s += diff(exp, val)
 		return
 	}
 
 	miss := false
 	for i := 0; i < lenA; i++ {
-		if !eq(expectation[i], value[i]) {
+		if !eq(exp[i], val[i]) {
 			miss = true
 			break
 		}
@@ -255,54 +255,54 @@ func EqSliceFunc[A any](expectation, value []A, eq func(a, b A) bool) (s string)
 
 	if miss {
 		s = "expected slice equality via 'eq' function\n"
-		s += diff(expectation, value)
+		s += diff(exp, val)
 		return
 	}
 
 	return
 }
 
-func Equal[E interfaces.EqualFunc[E]](expectation, value E) (s string) {
-	if !value.Equal(expectation) {
+func Equal[E interfaces.EqualFunc[E]](exp, val E) (s string) {
+	if !val.Equal(exp) {
 		s = "expected equality via .Equal method\n"
-		s += diff(expectation, value)
+		s += diff(exp, val)
 	}
 	return
 }
 
-func NotEqual[E interfaces.EqualFunc[E]](expectation, value E) (s string) {
-	if value.Equal(expectation) {
+func NotEqual[E interfaces.EqualFunc[E]](exp, val E) (s string) {
+	if val.Equal(exp) {
 		s = "expected inequality via .Equal method\n"
-		s += diff(expectation, value)
+		s += diff(exp, val)
 	}
 	return
 }
 
-func SliceEqual[E interfaces.EqualFunc[E]](expectation, value []E) (s string) {
-	lenA, lenB := len(expectation), len(value)
+func SliceEqual[E interfaces.EqualFunc[E]](exp, val []E) (s string) {
+	lenA, lenB := len(exp), len(val)
 
 	if lenA != lenB {
 		s = "expected slices of same length\n"
 		s += fmt.Sprintf("↪ len(exp): %d\n", lenA)
 		s += fmt.Sprintf("↪ len(val): %d\n", lenB)
-		s += diff(expectation, value)
+		s += diff(exp, val)
 		return
 	}
 
 	for i := 0; i < lenA; i++ {
-		if !expectation[i].Equal(value[i]) {
+		if !exp[i].Equal(val[i]) {
 			s += "expected slice equality via .Equal method\n"
-			s += diff(expectation[i], value[i])
+			s += diff(exp[i], val[i])
 			return
 		}
 	}
 	return
 }
 
-func Lesser[L interfaces.LessFunc[L]](expectation, value L) (s string) {
-	if !value.Less(expectation) {
-		s = "expected value to be less via .Less method\n"
-		s += diff(expectation, value)
+func Lesser[L interfaces.LessFunc[L]](exp, val L) (s string) {
+	if !val.Less(exp) {
+		s = "expected val to be less via .Less method\n"
+		s += diff(exp, val)
 	}
 	return
 }
@@ -393,15 +393,6 @@ OUTER:
 	return
 }
 
-func ContainsString(original, sub string) (s string) {
-	if !strings.Contains(original, sub) {
-		s = "expected to contain substring\n"
-		s += fmt.Sprintf("↪ str: %s\n", original)
-		s += fmt.Sprintf("↪ sub: %s\n", sub)
-	}
-	return
-}
-
 func Positive[N interfaces.Number](n N) (s string) {
 	if !(n > 0) {
 		s = "expected positive value\n"
@@ -442,47 +433,47 @@ func One[N interfaces.Number](n N) (s string) {
 	return
 }
 
-func Less[O constraints.Ordered](expectation, value O) (s string) {
-	if !(value < expectation) {
-		s = fmt.Sprintf("expected %v < %v", value, expectation)
+func Less[O constraints.Ordered](exp, val O) (s string) {
+	if !(val < exp) {
+		s = fmt.Sprintf("expected %v < %v", val, exp)
 	}
 	return
 }
 
-func LessEq[O constraints.Ordered](expectation, value O) (s string) {
-	if !(value <= expectation) {
-		s = fmt.Sprintf("expected %v ≤ %v", value, expectation)
+func LessEq[O constraints.Ordered](exp, val O) (s string) {
+	if !(val <= exp) {
+		s = fmt.Sprintf("expected %v ≤ %v", val, exp)
 	}
 	return
 }
 
-func Greater[O constraints.Ordered](expectation, value O) (s string) {
-	if !(value > expectation) {
-		s = fmt.Sprintf("expected %v > %v", value, expectation)
+func Greater[O constraints.Ordered](exp, val O) (s string) {
+	if !(val > exp) {
+		s = fmt.Sprintf("expected %v > %v", val, exp)
 	}
 	return
 }
 
-func GreaterEq[O constraints.Ordered](expectation, value O) (s string) {
-	if !(value >= expectation) {
-		s = fmt.Sprintf("expected %v ≥ %v", value, expectation)
+func GreaterEq[O constraints.Ordered](exp, val O) (s string) {
+	if !(val >= exp) {
+		s = fmt.Sprintf("expected %v ≥ %v", val, exp)
 	}
 	return
 }
 
-func Between[O constraints.Ordered](lower, value, upper O) (s string) {
-	if value < lower || value > upper {
-		s = fmt.Sprintf("expected value in range (%v ≤ value ≤ %v)\n", lower, upper)
-		s += fmt.Sprintf("↪ value: %v\n", value)
+func Between[O constraints.Ordered](lower, val, upper O) (s string) {
+	if val < lower || val > upper {
+		s = fmt.Sprintf("expected val in range (%v ≤ val ≤ %v)\n", lower, upper)
+		s += fmt.Sprintf("↪ val: %v\n", val)
 		return
 	}
 	return
 }
 
-func BetweenExclusive[O constraints.Ordered](lower, value, upper O) (s string) {
-	if value <= lower || value >= upper {
-		s = fmt.Sprintf("expected value in range (%v < value < %v)\n", lower, upper)
-		s += fmt.Sprintf("↪ value: %v\n", value)
+func BetweenExclusive[O constraints.Ordered](lower, val, upper O) (s string) {
+	if val <= lower || val >= upper {
+		s = fmt.Sprintf("expected val in range (%v < val < %v)\n", lower, upper)
+		s += fmt.Sprintf("↪ val: %v\n", val)
 		return
 	}
 	return
@@ -608,8 +599,8 @@ func InDeltaSlice[N interfaces.Number](a, b []N, delta N) (s string) {
 	return
 }
 
-func MapEq[M1, M2 interfaces.Map[K, V], K comparable, V any](expectation M1, value M2) (s string) {
-	lenA, lenB := len(expectation), len(value)
+func MapEq[M1, M2 interfaces.Map[K, V], K comparable, V any](exp M1, val M2) (s string) {
+	lenA, lenB := len(exp), len(val)
 
 	if lenA != lenB {
 		s = "expected maps of same length\n"
@@ -618,25 +609,25 @@ func MapEq[M1, M2 interfaces.Map[K, V], K comparable, V any](expectation M1, val
 		return
 	}
 
-	for key, valueA := range expectation {
-		valueB, exists := value[key]
+	for key, valA := range exp {
+		valB, exists := val[key]
 		if !exists {
 			s = "expected maps of same keys\n"
-			s += diff(expectation, value)
+			s += diff(exp, val)
 			return
 		}
 
-		if !cmp.Equal(valueA, valueB) {
+		if !cmp.Equal(valA, valB) {
 			s = "expected maps of same values via cmp.Diff function\n"
-			s += diff(expectation, value)
+			s += diff(exp, val)
 			return
 		}
 	}
 	return
 }
 
-func MapEqFunc[M1, M2 interfaces.Map[K, V], K comparable, V any](expectation M1, value M2, eq func(V, V) bool) (s string) {
-	lenA, lenB := len(expectation), len(value)
+func MapEqFunc[M1, M2 interfaces.Map[K, V], K comparable, V any](exp M1, val M2, eq func(V, V) bool) (s string) {
+	lenA, lenB := len(exp), len(val)
 
 	if lenA != lenB {
 		s = "expected maps of same length\n"
@@ -645,25 +636,25 @@ func MapEqFunc[M1, M2 interfaces.Map[K, V], K comparable, V any](expectation M1,
 		return
 	}
 
-	for key, valueA := range expectation {
-		valueB, exists := value[key]
+	for key, valA := range exp {
+		valB, exists := val[key]
 		if !exists {
 			s = "expected maps of same keys\n"
-			s += diff(expectation, value)
+			s += diff(exp, val)
 			return
 		}
 
-		if !eq(valueA, valueB) {
+		if !eq(valA, valB) {
 			s = "expected maps of same values via 'eq' function\n"
-			s += diff(expectation, value)
+			s += diff(exp, val)
 			return
 		}
 	}
 	return
 }
 
-func MapEqual[M interfaces.MapEqualFunc[K, V], K comparable, V interfaces.EqualFunc[V]](expectation, value M) (s string) {
-	lenA, lenB := len(expectation), len(value)
+func MapEqual[M interfaces.MapEqualFunc[K, V], K comparable, V interfaces.EqualFunc[V]](exp, val M) (s string) {
+	lenA, lenB := len(exp), len(val)
 
 	if lenA != lenB {
 		s = "expected maps of same length\n"
@@ -672,17 +663,17 @@ func MapEqual[M interfaces.MapEqualFunc[K, V], K comparable, V interfaces.EqualF
 		return
 	}
 
-	for key, valueA := range expectation {
-		valueB, exists := value[key]
+	for key, valA := range exp {
+		valB, exists := val[key]
 		if !exists {
 			s = "expected maps of same keys\n"
-			s += diff(expectation, value)
+			s += diff(exp, val)
 			return
 		}
 
-		if !(valueB).Equal(valueA) {
+		if !(valB).Equal(valA) {
 			s = "expected maps of same values via .Equal method\n"
-			s += diff(expectation, value)
+			s += diff(exp, val)
 			return
 		}
 	}
@@ -748,25 +739,25 @@ func mapContains[M ~map[K]V, K comparable, V any](m M, values []V, eq func(V, V)
 
 	if len(missing) > 0 {
 		s = "expected map to contain values\n"
-		for _, value := range missing {
-			s += fmt.Sprintf("↪ value: %v\n", value)
+		for _, val := range missing {
+			s += fmt.Sprintf("↪ val: %v\n", val)
 		}
 	}
 	return
 }
 
-func MapContainsValues[M ~map[K]V, K comparable, V any](m M, values []V) (s string) {
-	return mapContains[M, K, V](m, values, func(a, b V) bool {
+func MapContainsValues[M ~map[K]V, K comparable, V any](m M, vals []V) (s string) {
+	return mapContains[M, K, V](m, vals, func(a, b V) bool {
 		return equal(a, b)
 	})
 }
 
-func MapContainsValuesFunc[M ~map[K]V, K comparable, V any](m M, values []V, eq func(V, V) bool) (s string) {
-	return mapContains[M, K, V](m, values, eq)
+func MapContainsValuesFunc[M ~map[K]V, K comparable, V any](m M, vals []V, eq func(V, V) bool) (s string) {
+	return mapContains[M, K, V](m, vals, eq)
 }
 
-func MapContainsValuesEqual[M ~map[K]V, K comparable, V interfaces.EqualFunc[V]](m M, values []V) (s string) {
-	return mapContains[M, K, V](m, values, func(a, b V) bool {
+func MapContainsValuesEqual[M ~map[K]V, K comparable, V interfaces.EqualFunc[V]](m M, vals []V) (s string) {
+	return mapContains[M, K, V](m, vals, func(a, b V) bool {
 		return a.Equal(b)
 	})
 }
@@ -871,20 +862,20 @@ func FilePathValid(path string) (s string) {
 	return
 }
 
-func StrEqFold(expectation, value string) (s string) {
-	if !strings.EqualFold(expectation, value) {
+func StrEqFold(exp, val string) (s string) {
+	if !strings.EqualFold(exp, val) {
 		s = "expected strings to be equal ignoring case\n"
-		s += fmt.Sprintf("↪ exp: %s\n", expectation)
-		s += fmt.Sprintf("↪ val: %s\n", value)
+		s += fmt.Sprintf("↪ exp: %s\n", exp)
+		s += fmt.Sprintf("↪ val: %s\n", val)
 	}
 	return
 }
 
-func StrNotEqFold(expectation, value string) (s string) {
-	if strings.EqualFold(expectation, value) {
+func StrNotEqFold(exp, val string) (s string) {
+	if strings.EqualFold(exp, val) {
 		s = "expected strings to not be equal ignoring case; but they are\n"
-		s += fmt.Sprintf("↪ exp: %s\n", expectation)
-		s += fmt.Sprintf("↪ val: %s\n", value)
+		s += fmt.Sprintf("↪ exp: %s\n", exp)
+		s += fmt.Sprintf("↪ val: %s\n", val)
 	}
 	return
 }

--- a/internal/assertions/assertions.go
+++ b/internal/assertions/assertions.go
@@ -165,60 +165,60 @@ func NoError(err error) (s string) {
 	return
 }
 
-func Eq[A any](a, b A) (s string) {
-	if !equal(a, b) {
+func Eq[A any](expectation, value A) (s string) {
+	if !equal(expectation, value) {
 		s = "expected equality via cmp.Equal function\n"
-		s += diff(a, b)
+		s += diff(expectation, value)
 	}
 	return
 }
 
-func NotEq[A any](a, b A) (s string) {
-	if equal(a, b) {
+func NotEq[A any](expectation, value A) (s string) {
+	if equal(expectation, value) {
 		s = "expected inequality via cmp.Equal function\n"
 	}
 	return
 }
 
-func EqOp[C comparable](a, b C) (s string) {
-	if a != b {
+func EqOp[C comparable](expectation, value C) (s string) {
+	if expectation != value {
 		s = "expected equality via ==\n"
-		s += diff(a, b)
+		s += diff(expectation, value)
 	}
 	return
 }
 
-func EqFunc[A any](a, b A, eq func(a, b A) bool) (s string) {
-	if !eq(a, b) {
+func EqFunc[A any](expectation, value A, eq func(a, b A) bool) (s string) {
+	if !eq(expectation, value) {
 		s = "expected equality via 'eq' function\n"
-		s += diff(a, b)
+		s += diff(expectation, value)
 	}
 	return
 }
 
-func NotEqOp[C comparable](a, b C) (s string) {
-	if a == b {
+func NotEqOp[C comparable](expectation, value C) (s string) {
+	if expectation == value {
 		s = "expected inequality via !="
 	}
 	return
 }
 
-func NotEqFunc[A any](a, b A, eq func(a, b A) bool) (s string) {
-	if eq(a, b) {
+func NotEqFunc[A any](expectation, value A, eq func(a, b A) bool) (s string) {
+	if eq(expectation, value) {
 		s = "expected inequality via 'eq' function"
 	}
 	return
 }
 
-func EqJSON(a, b string) (s string) {
+func EqJSON(expectation, value string) (s string) {
 	var expA, expB any
 
-	if err := json.Unmarshal([]byte(a), &expA); err != nil {
+	if err := json.Unmarshal([]byte(expectation), &expA); err != nil {
 		s = fmt.Sprintf("failed to unmarshal first argument as json: %v", err)
 		return
 	}
 
-	if err := json.Unmarshal([]byte(b), &expB); err != nil {
+	if err := json.Unmarshal([]byte(value), &expB); err != nil {
 		s = fmt.Sprintf("failed to unmarshal second argument as json: %v", err)
 		return
 	}
@@ -234,20 +234,20 @@ func EqJSON(a, b string) (s string) {
 	return
 }
 
-func EqSliceFunc[A any](a, b []A, eq func(a, b A) bool) (s string) {
-	lenA, lenB := len(a), len(b)
+func EqSliceFunc[A any](expectation, value []A, eq func(a, b A) bool) (s string) {
+	lenA, lenB := len(expectation), len(value)
 
 	if lenA != lenB {
 		s = "expected slices of same length\n"
-		s += fmt.Sprintf("↪ len(slice a): %d\n", lenA)
-		s += fmt.Sprintf("↪ len(slice b): %d\n", lenB)
-		s += diff(a, b)
+		s += fmt.Sprintf("↪ len(exp): %d\n", lenA)
+		s += fmt.Sprintf("↪ len(val): %d\n", lenB)
+		s += diff(expectation, value)
 		return
 	}
 
 	miss := false
 	for i := 0; i < lenA; i++ {
-		if !eq(a[i], b[i]) {
+		if !eq(expectation[i], value[i]) {
 			miss = true
 			break
 		}
@@ -255,54 +255,54 @@ func EqSliceFunc[A any](a, b []A, eq func(a, b A) bool) (s string) {
 
 	if miss {
 		s = "expected slice equality via 'eq' function\n"
-		s += diff(a, b)
+		s += diff(expectation, value)
 		return
 	}
 
 	return
 }
 
-func Equal[E interfaces.EqualFunc[E]](a, b E) (s string) {
-	if !a.Equal(b) {
+func Equal[E interfaces.EqualFunc[E]](expectation, value E) (s string) {
+	if !value.Equal(expectation) {
 		s = "expected equality via .Equal method\n"
-		s += diff(a, b)
+		s += diff(expectation, value)
 	}
 	return
 }
 
-func NotEqual[E interfaces.EqualFunc[E]](a, b E) (s string) {
-	if a.Equal(b) {
+func NotEqual[E interfaces.EqualFunc[E]](expectation, value E) (s string) {
+	if value.Equal(expectation) {
 		s = "expected inequality via .Equal method\n"
-		s += diff(a, b)
+		s += diff(expectation, value)
 	}
 	return
 }
 
-func SliceEqual[E interfaces.EqualFunc[E]](a, b []E) (s string) {
-	lenA, lenB := len(a), len(b)
+func SliceEqual[E interfaces.EqualFunc[E]](expectation, value []E) (s string) {
+	lenA, lenB := len(expectation), len(value)
 
 	if lenA != lenB {
 		s = "expected slices of same length\n"
-		s += fmt.Sprintf("↪ len(slice a): %d\n", lenA)
-		s += fmt.Sprintf("↪ len(slice b): %d\n", lenB)
-		s += diff(a, b)
+		s += fmt.Sprintf("↪ len(exp): %d\n", lenA)
+		s += fmt.Sprintf("↪ len(val): %d\n", lenB)
+		s += diff(expectation, value)
 		return
 	}
 
 	for i := 0; i < lenA; i++ {
-		if !a[i].Equal(b[i]) {
+		if !expectation[i].Equal(value[i]) {
 			s += "expected slice equality via .Equal method\n"
-			s += diff(a[i], b[i])
+			s += diff(expectation[i], value[i])
 			return
 		}
 	}
 	return
 }
 
-func Lesser[L interfaces.LessFunc[L]](a, b L) (s string) {
-	if !a.Less(b) {
-		s = "expected to be less via .Less method\n"
-		s += diff(a, b)
+func Lesser[L interfaces.LessFunc[L]](expectation, value L) (s string) {
+	if !value.Less(expectation) {
+		s = "expected value to be less via .Less method\n"
+		s += diff(expectation, value)
 	}
 	return
 }
@@ -442,30 +442,30 @@ func One[N interfaces.Number](n N) (s string) {
 	return
 }
 
-func Less[O constraints.Ordered](a, b O) (s string) {
-	if !(a < b) {
-		s = fmt.Sprintf("expected %v < %v", a, b)
+func Less[O constraints.Ordered](expectation, value O) (s string) {
+	if !(value < expectation) {
+		s = fmt.Sprintf("expected %v < %v", value, expectation)
 	}
 	return
 }
 
-func LessEq[O constraints.Ordered](a, b O) (s string) {
-	if !(a <= b) {
-		s = fmt.Sprintf("expected %v <= %v", a, b)
+func LessEq[O constraints.Ordered](expectation, value O) (s string) {
+	if !(value <= expectation) {
+		s = fmt.Sprintf("expected %v ≤ %v", value, expectation)
 	}
 	return
 }
 
-func Greater[O constraints.Ordered](a, b O) (s string) {
-	if !(a > b) {
-		s = fmt.Sprintf("expected %v > %v", a, b)
+func Greater[O constraints.Ordered](expectation, value O) (s string) {
+	if !(value > expectation) {
+		s = fmt.Sprintf("expected %v > %v", value, expectation)
 	}
 	return
 }
 
-func GreaterEq[O constraints.Ordered](a, b O) (s string) {
-	if !(a >= b) {
-		s = fmt.Sprintf("expected %v >= %v", a, b)
+func GreaterEq[O constraints.Ordered](expectation, value O) (s string) {
+	if !(value >= expectation) {
+		s = fmt.Sprintf("expected %v ≥ %v", value, expectation)
 	}
 	return
 }
@@ -608,81 +608,81 @@ func InDeltaSlice[N interfaces.Number](a, b []N, delta N) (s string) {
 	return
 }
 
-func MapEq[M1, M2 interfaces.Map[K, V], K comparable, V any](a M1, b M2) (s string) {
-	lenA, lenB := len(a), len(b)
+func MapEq[M1, M2 interfaces.Map[K, V], K comparable, V any](expectation M1, value M2) (s string) {
+	lenA, lenB := len(expectation), len(value)
 
 	if lenA != lenB {
 		s = "expected maps of same length\n"
-		s += fmt.Sprintf("↪ len(map a): %d\n", lenA)
-		s += fmt.Sprintf("↪ len(map b): %d\n", lenB)
+		s += fmt.Sprintf("↪ len(exp): %d\n", lenA)
+		s += fmt.Sprintf("↪ len(val): %d\n", lenB)
 		return
 	}
 
-	for key, valueA := range a {
-		valueB, exists := b[key]
+	for key, valueA := range expectation {
+		valueB, exists := value[key]
 		if !exists {
 			s = "expected maps of same keys\n"
-			s += diff(a, b)
+			s += diff(expectation, value)
 			return
 		}
 
 		if !cmp.Equal(valueA, valueB) {
 			s = "expected maps of same values via cmp.Diff function\n"
-			s += diff(a, b)
+			s += diff(expectation, value)
 			return
 		}
 	}
 	return
 }
 
-func MapEqFunc[M1, M2 interfaces.Map[K, V], K comparable, V any](a M1, b M2, eq func(V, V) bool) (s string) {
-	lenA, lenB := len(a), len(b)
+func MapEqFunc[M1, M2 interfaces.Map[K, V], K comparable, V any](expectation M1, value M2, eq func(V, V) bool) (s string) {
+	lenA, lenB := len(expectation), len(value)
 
 	if lenA != lenB {
 		s = "expected maps of same length\n"
-		s += fmt.Sprintf("↪ len(map a): %d\n", lenA)
-		s += fmt.Sprintf("↪ len(map b): %d\n", lenB)
+		s += fmt.Sprintf("↪ len(exp): %d\n", lenA)
+		s += fmt.Sprintf("↪ len(val): %d\n", lenB)
 		return
 	}
 
-	for key, valueA := range a {
-		valueB, exists := b[key]
+	for key, valueA := range expectation {
+		valueB, exists := value[key]
 		if !exists {
 			s = "expected maps of same keys\n"
-			s += diff(a, b)
+			s += diff(expectation, value)
 			return
 		}
 
 		if !eq(valueA, valueB) {
 			s = "expected maps of same values via 'eq' function\n"
-			s += diff(a, b)
+			s += diff(expectation, value)
 			return
 		}
 	}
 	return
 }
 
-func MapEqual[M interfaces.MapEqualFunc[K, V], K comparable, V interfaces.EqualFunc[V]](a, b M) (s string) {
-	lenA, lenB := len(a), len(b)
+func MapEqual[M interfaces.MapEqualFunc[K, V], K comparable, V interfaces.EqualFunc[V]](expectation, value M) (s string) {
+	lenA, lenB := len(expectation), len(value)
 
 	if lenA != lenB {
 		s = "expected maps of same length\n"
-		s += fmt.Sprintf("↪ len(map a): %d\n", lenA)
-		s += fmt.Sprintf("↪ len(map b): %d\n", lenB)
+		s += fmt.Sprintf("↪ len(exp): %d\n", lenA)
+		s += fmt.Sprintf("↪ len(val): %d\n", lenB)
 		return
 	}
 
-	for key, valueA := range a {
-		valueB, exists := b[key]
+	for key, valueA := range expectation {
+		valueB, exists := value[key]
 		if !exists {
 			s = "expected maps of same keys\n"
-			s += diff(a, b)
+			s += diff(expectation, value)
 			return
 		}
 
 		if !(valueB).Equal(valueA) {
 			s = "expected maps of same values via .Equal method\n"
-			s += diff(a, b)
+			s += diff(expectation, value)
 			return
 		}
 	}
@@ -871,20 +871,20 @@ func FilePathValid(path string) (s string) {
 	return
 }
 
-func StrEqFold(first, second string) (s string) {
-	if !strings.EqualFold(first, second) {
+func StrEqFold(expectation, value string) (s string) {
+	if !strings.EqualFold(expectation, value) {
 		s = "expected strings to be equal ignoring case\n"
-		s += fmt.Sprintf("↪  first: %s\n", first)
-		s += fmt.Sprintf("↪ second: %s\n", second)
+		s += fmt.Sprintf("↪ exp: %s\n", expectation)
+		s += fmt.Sprintf("↪ val: %s\n", value)
 	}
 	return
 }
 
-func StrNotEqFold(first, second string) (s string) {
-	if strings.EqualFold(first, second) {
+func StrNotEqFold(expectation, value string) (s string) {
+	if strings.EqualFold(expectation, value) {
 		s = "expected strings to not be equal ignoring case; but they are\n"
-		s += fmt.Sprintf("↪  first: %s\n", first)
-		s += fmt.Sprintf("↪ second: %s\n", second)
+		s += fmt.Sprintf("↪ exp: %s\n", expectation)
+		s += fmt.Sprintf("↪ val: %s\n", value)
 	}
 	return
 }

--- a/must/must.go
+++ b/must/must.go
@@ -67,76 +67,76 @@ func NoError(t T, err error, scripts ...PostScript) {
 	invoke(t, assertions.NoError(err), scripts...)
 }
 
-// Eq asserts a and b are equal using cmp.Equal.
-func Eq[A any](t T, a, b A, scripts ...PostScript) {
+// Eq asserts expectation and value are equal using cmp.Equal.
+func Eq[A any](t T, expectation, value A, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.Eq(a, b), scripts...)
+	invoke(t, assertions.Eq(expectation, value), scripts...)
 }
 
-// EqOp asserts a == b.
-func EqOp[C comparable](t T, a, b C, scripts ...PostScript) {
+// EqOp asserts expectation == value.
+func EqOp[C comparable](t T, expectation, value C, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.EqOp(a, b), scripts...)
+	invoke(t, assertions.EqOp(expectation, value), scripts...)
 }
 
-// EqFunc asserts a and b are equal using eq.
-func EqFunc[A any](t T, a, b A, eq func(a, b A) bool, scripts ...PostScript) {
+// EqFunc asserts expectation and value are equal using eq.
+func EqFunc[A any](t T, expectation, value A, eq func(a, b A) bool, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.EqFunc(a, b, eq), scripts...)
+	invoke(t, assertions.EqFunc(expectation, value, eq), scripts...)
 }
 
-// NotEq asserts a and b are not equal using cmp.Equal.
-func NotEq[A any](t T, a, b A, scripts ...PostScript) {
+// NotEq asserts expectation and value are not equal using cmp.Equal.
+func NotEq[A any](t T, expectation, value A, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.NotEq(a, b), scripts...)
+	invoke(t, assertions.NotEq(expectation, value), scripts...)
 }
 
-// NotEqOp asserts a != b.
-func NotEqOp[C comparable](t T, a, b C, scripts ...PostScript) {
+// NotEqOp asserts expectation != value.
+func NotEqOp[C comparable](t T, expectation, value C, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.NotEqOp(a, b), scripts...)
+	invoke(t, assertions.NotEqOp(expectation, value), scripts...)
 }
 
-// NotEqFunc asserts a and b are not equal using eq.
-func NotEqFunc[A any](t T, a, b A, eq func(a, b A) bool, scripts ...PostScript) {
+// NotEqFunc asserts expectation and value are not equal using eq.
+func NotEqFunc[A any](t T, expectation, value A, eq func(a, b A) bool, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.NotEqFunc(a, b, eq), scripts...)
+	invoke(t, assertions.NotEqFunc(expectation, value, eq), scripts...)
 }
 
-// EqJSON asserts a and b are equivalent JSON.
-func EqJSON(t T, a, b string, scripts ...PostScript) {
+// EqJSON asserts expectation and value are equivalent JSON.
+func EqJSON(t T, expectation, value string, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.EqJSON(a, b), scripts...)
+	invoke(t, assertions.EqJSON(expectation, value), scripts...)
 }
 
-// SliceEqFunc asserts elements of a and b are the same using eq.
-func SliceEqFunc[A any](t T, a, b []A, eq func(a, b A) bool, scripts ...PostScript) {
+// Equal asserts value.Equal(expectation).
+func Equal[E interfaces.EqualFunc[E]](t T, expectation, value E, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.EqSliceFunc(a, b, eq), scripts...)
+	invoke(t, assertions.Equal(expectation, value), scripts...)
 }
 
-// Equal asserts a.Equal(b).
-func Equal[E interfaces.EqualFunc[E]](t T, a, b E, scripts ...PostScript) {
+// NotEqual asserts !value.Equal(expectation).
+func NotEqual[E interfaces.EqualFunc[E]](t T, expectation, value E, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.Equal(a, b), scripts...)
+	invoke(t, assertions.NotEqual(expectation, value), scripts...)
 }
 
-// NotEqual asserts !a.Equal(b).
-func NotEqual[E interfaces.EqualFunc[E]](t T, a, b E, scripts ...PostScript) {
+// Lesser asserts value.Less(expectation).
+func Lesser[L interfaces.LessFunc[L]](t T, expectation, value L, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.NotEqual(a, b), scripts...)
+	invoke(t, assertions.Lesser(expectation, value), scripts...)
 }
 
-// Lesser asserts a.Less(b).
-func Lesser[L interfaces.LessFunc[L]](t T, a, b L, scripts ...PostScript) {
+// SliceEqFunc asserts elements of expectation and value are the same using eq.
+func SliceEqFunc[A any](t T, expectation, value []A, eq func(a, b A) bool, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.Lesser(a, b), scripts...)
+	invoke(t, assertions.EqSliceFunc(expectation, value, eq), scripts...)
 }
 
-// SliceEqual asserts a[n].Equal(b[n]) for each element n in slices a and b.
-func SliceEqual[E interfaces.EqualFunc[E]](t T, a, b []E, scripts ...PostScript) {
+// SliceEqual asserts value[n].Equal(expectation[n]) for each element n.
+func SliceEqual[E interfaces.EqualFunc[E]](t T, expectation, value []E, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.SliceEqual(a, b), scripts...)
+	invoke(t, assertions.SliceEqual(expectation, value), scripts...)
 }
 
 // SliceEmpty asserts slice is empty.
@@ -231,28 +231,28 @@ func One[N interfaces.Number](t T, n N, scripts ...PostScript) {
 	invoke(t, assertions.One(n), scripts...)
 }
 
-// Less asserts a < b.
-func Less[O constraints.Ordered](t T, a, b O, scripts ...PostScript) {
+// Less asserts value < expectation.
+func Less[O constraints.Ordered](t T, expectation, value O, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.Less(a, b), scripts...)
+	invoke(t, assertions.Less(expectation, value), scripts...)
 }
 
-// LessEq asserts a <= b.
-func LessEq[O constraints.Ordered](t T, a, b O, scripts ...PostScript) {
+// LessEq asserts value ≤ expectation.
+func LessEq[O constraints.Ordered](t T, expectation, value O, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.LessEq(a, b), scripts...)
+	invoke(t, assertions.LessEq(expectation, value), scripts...)
 }
 
-// Greater asserts a > b.
-func Greater[O constraints.Ordered](t T, a, b O, scripts ...PostScript) {
+// Greater asserts value > expectation.
+func Greater[O constraints.Ordered](t T, expectation, value O, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.Greater(a, b), scripts...)
+	invoke(t, assertions.Greater(expectation, value), scripts...)
 }
 
-// GreaterEq asserts a >= b.
-func GreaterEq[O constraints.Ordered](t T, a, b O, scripts ...PostScript) {
+// GreaterEq asserts value ≥ expectation.
+func GreaterEq[O constraints.Ordered](t T, expectation, value O, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.GreaterEq(a, b), scripts...)
+	invoke(t, assertions.GreaterEq(expectation, value), scripts...)
 }
 
 // Between asserts lower ≤ value ≤ upper.
@@ -267,7 +267,7 @@ func BetweenExclusive[O constraints.Ordered](t T, lower, value, upper O, scripts
 	invoke(t, assertions.BetweenExclusive(lower, value, upper), scripts...)
 }
 
-// Ascending asserts slice[n] <= slice[n+1] for each element n.
+// Ascending asserts slice[n] ≤ slice[n+1] for each element n.
 func Ascending[O constraints.Ordered](t T, slice []O, scripts ...PostScript) {
 	t.Helper()
 	invoke(t, assertions.Ascending(slice), scripts...)
@@ -285,7 +285,7 @@ func AscendingLess[L interfaces.LessFunc[L]](t T, slice []L, scripts ...PostScri
 	invoke(t, assertions.AscendingLess(slice), scripts...)
 }
 
-// Descending asserts slice[n] >= slice[n+1] for each element n.
+// Descending asserts slice[n] ≥ slice[n+1] for each element n.
 func Descending[O constraints.Ordered](t T, slice []O, scripts ...PostScript) {
 	t.Helper()
 	invoke(t, assertions.Descending(slice), scripts...)
@@ -315,25 +315,25 @@ func InDeltaSlice[N interfaces.Number](t T, a, b []N, delta N, scripts ...PostSc
 	invoke(t, assertions.InDeltaSlice(a, b, delta), scripts...)
 }
 
-// MapEq asserts maps a and b contain the same key/value pairs, using
+// MapEq asserts maps expectation and value contain the same key/value pairs, using
 // cmp.Equal function to compare values.
-func MapEq[M1, M2 interfaces.Map[K, V], K comparable, V any](t T, a M1, b M2, scripts ...PostScript) {
+func MapEq[M1, M2 interfaces.Map[K, V], K comparable, V any](t T, expectation M1, value M2, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.MapEq[M1, M2, K, V](a, b), scripts...)
+	invoke(t, assertions.MapEq[M1, M2, K, V](expectation, value), scripts...)
 }
 
-// MapEqFunc asserts maps a and b contain the same key/value pairs, using eq to
+// MapEqFunc asserts maps expectation and value contain the same key/value pairs, using eq to
 // compare values.
-func MapEqFunc[M1, M2 interfaces.Map[K, V], K comparable, V any](t T, a M1, b M2, eq func(V, V) bool, scripts ...PostScript) {
+func MapEqFunc[M1, M2 interfaces.Map[K, V], K comparable, V any](t T, expectation M1, value M2, eq func(V, V) bool, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.MapEqFunc[M1, M2, K, V](a, b, eq), scripts...)
+	invoke(t, assertions.MapEqFunc[M1, M2, K, V](expectation, value, eq), scripts...)
 }
 
-// MapEqual asserts maps a and b contain the same key/value pairs, using Equal
+// MapEqual asserts maps expectation and value contain the same key/value pairs, using Equal
 // method to compare values
-func MapEqual[M interfaces.MapEqualFunc[K, V], K comparable, V interfaces.EqualFunc[V]](t T, a, b M, scripts ...PostScript) {
+func MapEqual[M interfaces.MapEqualFunc[K, V], K comparable, V interfaces.EqualFunc[V]](t T, expectation, value M, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.MapEqual[M, K, V](a, b), scripts...)
+	invoke(t, assertions.MapEqual[M, K, V](expectation, value), scripts...)
 }
 
 // MapLen asserts map is of size n.
@@ -479,16 +479,16 @@ func FilePathValid(t T, path string, scripts ...PostScript) {
 	invoke(t, assertions.FilePathValid(path), scripts...)
 }
 
-// StrEqFold asserts first and second are equivalent, ignoring case.
-func StrEqFold(t T, first, second string, scripts ...PostScript) {
+// StrEqFold asserts expectation and value are equivalent, ignoring case.
+func StrEqFold(t T, expectation, value string, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.StrEqFold(first, second), scripts...)
+	invoke(t, assertions.StrEqFold(expectation, value), scripts...)
 }
 
-// StrNotEqFold asserts first and second are not equivalent, ignoring case.
-func StrNotEqFold(t T, first, second string, scripts ...PostScript) {
+// StrNotEqFold asserts expectation and value are not equivalent, ignoring case.
+func StrNotEqFold(t T, expectation, value string, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.StrNotEqFold(first, second), scripts...)
+	invoke(t, assertions.StrNotEqFold(expectation, value), scripts...)
 }
 
 // StrContains asserts s contains substring sub.

--- a/must/must.go
+++ b/must/must.go
@@ -67,76 +67,76 @@ func NoError(t T, err error, scripts ...PostScript) {
 	invoke(t, assertions.NoError(err), scripts...)
 }
 
-// Eq asserts expectation and value are equal using cmp.Equal.
-func Eq[A any](t T, expectation, value A, scripts ...PostScript) {
+// Eq asserts exp and val are equal using cmp.Equal.
+func Eq[A any](t T, exp, val A, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.Eq(expectation, value), scripts...)
+	invoke(t, assertions.Eq(exp, val), scripts...)
 }
 
-// EqOp asserts expectation == value.
-func EqOp[C comparable](t T, expectation, value C, scripts ...PostScript) {
+// EqOp asserts exp == val.
+func EqOp[C comparable](t T, exp, val C, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.EqOp(expectation, value), scripts...)
+	invoke(t, assertions.EqOp(exp, val), scripts...)
 }
 
-// EqFunc asserts expectation and value are equal using eq.
-func EqFunc[A any](t T, expectation, value A, eq func(a, b A) bool, scripts ...PostScript) {
+// EqFunc asserts exp and val are equal using eq.
+func EqFunc[A any](t T, exp, val A, eq func(a, b A) bool, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.EqFunc(expectation, value, eq), scripts...)
+	invoke(t, assertions.EqFunc(exp, val, eq), scripts...)
 }
 
-// NotEq asserts expectation and value are not equal using cmp.Equal.
-func NotEq[A any](t T, expectation, value A, scripts ...PostScript) {
+// NotEq asserts exp and val are not equal using cmp.Equal.
+func NotEq[A any](t T, exp, val A, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.NotEq(expectation, value), scripts...)
+	invoke(t, assertions.NotEq(exp, val), scripts...)
 }
 
-// NotEqOp asserts expectation != value.
-func NotEqOp[C comparable](t T, expectation, value C, scripts ...PostScript) {
+// NotEqOp asserts exp != val.
+func NotEqOp[C comparable](t T, exp, val C, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.NotEqOp(expectation, value), scripts...)
+	invoke(t, assertions.NotEqOp(exp, val), scripts...)
 }
 
-// NotEqFunc asserts expectation and value are not equal using eq.
-func NotEqFunc[A any](t T, expectation, value A, eq func(a, b A) bool, scripts ...PostScript) {
+// NotEqFunc asserts exp and val are not equal using eq.
+func NotEqFunc[A any](t T, exp, val A, eq func(a, b A) bool, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.NotEqFunc(expectation, value, eq), scripts...)
+	invoke(t, assertions.NotEqFunc(exp, val, eq), scripts...)
 }
 
-// EqJSON asserts expectation and value are equivalent JSON.
-func EqJSON(t T, expectation, value string, scripts ...PostScript) {
+// EqJSON asserts exp and val are equivalent JSON.
+func EqJSON(t T, exp, val string, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.EqJSON(expectation, value), scripts...)
+	invoke(t, assertions.EqJSON(exp, val), scripts...)
 }
 
-// Equal asserts value.Equal(expectation).
-func Equal[E interfaces.EqualFunc[E]](t T, expectation, value E, scripts ...PostScript) {
+// Equal asserts val.Equal(exp).
+func Equal[E interfaces.EqualFunc[E]](t T, exp, val E, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.Equal(expectation, value), scripts...)
+	invoke(t, assertions.Equal(exp, val), scripts...)
 }
 
-// NotEqual asserts !value.Equal(expectation).
-func NotEqual[E interfaces.EqualFunc[E]](t T, expectation, value E, scripts ...PostScript) {
+// NotEqual asserts !val.Equal(exp).
+func NotEqual[E interfaces.EqualFunc[E]](t T, exp, val E, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.NotEqual(expectation, value), scripts...)
+	invoke(t, assertions.NotEqual(exp, val), scripts...)
 }
 
-// Lesser asserts value.Less(expectation).
-func Lesser[L interfaces.LessFunc[L]](t T, expectation, value L, scripts ...PostScript) {
+// Lesser asserts val.Less(exp).
+func Lesser[L interfaces.LessFunc[L]](t T, exp, val L, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.Lesser(expectation, value), scripts...)
+	invoke(t, assertions.Lesser(exp, val), scripts...)
 }
 
-// SliceEqFunc asserts elements of expectation and value are the same using eq.
-func SliceEqFunc[A any](t T, expectation, value []A, eq func(a, b A) bool, scripts ...PostScript) {
+// SliceEqFunc asserts elements of exp and val are the same using eq.
+func SliceEqFunc[A any](t T, exp, val []A, eq func(a, b A) bool, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.EqSliceFunc(expectation, value, eq), scripts...)
+	invoke(t, assertions.EqSliceFunc(exp, val, eq), scripts...)
 }
 
-// SliceEqual asserts value[n].Equal(expectation[n]) for each element n.
-func SliceEqual[E interfaces.EqualFunc[E]](t T, expectation, value []E, scripts ...PostScript) {
+// SliceEqual asserts val[n].Equal(exp[n]) for each element n.
+func SliceEqual[E interfaces.EqualFunc[E]](t T, exp, val []E, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.SliceEqual(expectation, value), scripts...)
+	invoke(t, assertions.SliceEqual(exp, val), scripts...)
 }
 
 // SliceEmpty asserts slice is empty.
@@ -231,40 +231,40 @@ func One[N interfaces.Number](t T, n N, scripts ...PostScript) {
 	invoke(t, assertions.One(n), scripts...)
 }
 
-// Less asserts value < expectation.
-func Less[O constraints.Ordered](t T, expectation, value O, scripts ...PostScript) {
+// Less asserts val < exp.
+func Less[O constraints.Ordered](t T, exp, val O, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.Less(expectation, value), scripts...)
+	invoke(t, assertions.Less(exp, val), scripts...)
 }
 
-// LessEq asserts value ≤ expectation.
-func LessEq[O constraints.Ordered](t T, expectation, value O, scripts ...PostScript) {
+// LessEq asserts val ≤ exp.
+func LessEq[O constraints.Ordered](t T, exp, val O, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.LessEq(expectation, value), scripts...)
+	invoke(t, assertions.LessEq(exp, val), scripts...)
 }
 
-// Greater asserts value > expectation.
-func Greater[O constraints.Ordered](t T, expectation, value O, scripts ...PostScript) {
+// Greater asserts val > exp.
+func Greater[O constraints.Ordered](t T, exp, val O, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.Greater(expectation, value), scripts...)
+	invoke(t, assertions.Greater(exp, val), scripts...)
 }
 
-// GreaterEq asserts value ≥ expectation.
-func GreaterEq[O constraints.Ordered](t T, expectation, value O, scripts ...PostScript) {
+// GreaterEq asserts val ≥ exp.
+func GreaterEq[O constraints.Ordered](t T, exp, val O, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.GreaterEq(expectation, value), scripts...)
+	invoke(t, assertions.GreaterEq(exp, val), scripts...)
 }
 
-// Between asserts lower ≤ value ≤ upper.
-func Between[O constraints.Ordered](t T, lower, value, upper O, scripts ...PostScript) {
+// Between asserts lower ≤ val ≤ upper.
+func Between[O constraints.Ordered](t T, lower, val, upper O, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.Between(lower, value, upper), scripts...)
+	invoke(t, assertions.Between(lower, val, upper), scripts...)
 }
 
-// BetweenExclusive asserts lower < value < upper.
-func BetweenExclusive[O constraints.Ordered](t T, lower, value, upper O, scripts ...PostScript) {
+// BetweenExclusive asserts lower < val < upper.
+func BetweenExclusive[O constraints.Ordered](t T, lower, val, upper O, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.BetweenExclusive(lower, value, upper), scripts...)
+	invoke(t, assertions.BetweenExclusive(lower, val, upper), scripts...)
 }
 
 // Ascending asserts slice[n] ≤ slice[n+1] for each element n.
@@ -315,25 +315,25 @@ func InDeltaSlice[N interfaces.Number](t T, a, b []N, delta N, scripts ...PostSc
 	invoke(t, assertions.InDeltaSlice(a, b, delta), scripts...)
 }
 
-// MapEq asserts maps expectation and value contain the same key/value pairs, using
-// cmp.Equal function to compare values.
-func MapEq[M1, M2 interfaces.Map[K, V], K comparable, V any](t T, expectation M1, value M2, scripts ...PostScript) {
+// MapEq asserts maps exp and val contain the same key/val pairs, using
+// cmp.Equal function to compare vals.
+func MapEq[M1, M2 interfaces.Map[K, V], K comparable, V any](t T, exp M1, val M2, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.MapEq[M1, M2, K, V](expectation, value), scripts...)
+	invoke(t, assertions.MapEq[M1, M2, K, V](exp, val), scripts...)
 }
 
-// MapEqFunc asserts maps expectation and value contain the same key/value pairs, using eq to
-// compare values.
-func MapEqFunc[M1, M2 interfaces.Map[K, V], K comparable, V any](t T, expectation M1, value M2, eq func(V, V) bool, scripts ...PostScript) {
+// MapEqFunc asserts maps exp and val contain the same key/val pairs, using eq to
+// compare vals.
+func MapEqFunc[M1, M2 interfaces.Map[K, V], K comparable, V any](t T, exp M1, val M2, eq func(V, V) bool, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.MapEqFunc[M1, M2, K, V](expectation, value, eq), scripts...)
+	invoke(t, assertions.MapEqFunc[M1, M2, K, V](exp, val, eq), scripts...)
 }
 
-// MapEqual asserts maps expectation and value contain the same key/value pairs, using Equal
-// method to compare values
-func MapEqual[M interfaces.MapEqualFunc[K, V], K comparable, V interfaces.EqualFunc[V]](t T, expectation, value M, scripts ...PostScript) {
+// MapEqual asserts maps exp and val contain the same key/val pairs, using Equal
+// method to compare vals
+func MapEqual[M interfaces.MapEqualFunc[K, V], K comparable, V interfaces.EqualFunc[V]](t T, exp, val M, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.MapEqual[M, K, V](expectation, value), scripts...)
+	invoke(t, assertions.MapEqual[M, K, V](exp, val), scripts...)
 }
 
 // MapLen asserts map is of size n.
@@ -360,21 +360,21 @@ func MapContainsKeys[M ~map[K]V, K comparable, V any](t T, m M, keys []K, script
 	invoke(t, assertions.MapContainsKeys[M, K, V](m, keys), scripts...)
 }
 
-// MapContainsValues asserts m contains each value in values.
-func MapContainsValues[M ~map[K]V, K comparable, V any](t T, m M, values []V, scripts ...PostScript) {
+// MapContainsValues asserts m contains each val in vals.
+func MapContainsValues[M ~map[K]V, K comparable, V any](t T, m M, vals []V, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.MapContainsValues[M, K, V](m, values), scripts...)
+	invoke(t, assertions.MapContainsValues[M, K, V](m, vals), scripts...)
 }
 
-// MapContainsValuesFunc asserts m contains each value in values using the eq function.
-func MapContainsValuesFunc[M ~map[K]V, K comparable, V any](t T, m M, values []V, eq func(V, V) bool, scripts ...PostScript) {
+// MapContainsValuesFunc asserts m contains each val in vals using the eq function.
+func MapContainsValuesFunc[M ~map[K]V, K comparable, V any](t T, m M, vals []V, eq func(V, V) bool, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.MapContainsValuesFunc[M, K, V](m, values, eq), scripts...)
+	invoke(t, assertions.MapContainsValuesFunc[M, K, V](m, vals, eq), scripts...)
 }
 
-func MapContainsValuesEqual[M ~map[K]V, K comparable, V interfaces.EqualFunc[V]](t T, m M, values []V, scripts ...PostScript) {
+func MapContainsValuesEqual[M ~map[K]V, K comparable, V interfaces.EqualFunc[V]](t T, m M, vals []V, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.MapContainsValuesEqual[M, K, V](m, values), scripts...)
+	invoke(t, assertions.MapContainsValuesEqual[M, K, V](m, vals), scripts...)
 }
 
 // FileExistsFS asserts file exists on the fs.FS filesystem.
@@ -479,16 +479,16 @@ func FilePathValid(t T, path string, scripts ...PostScript) {
 	invoke(t, assertions.FilePathValid(path), scripts...)
 }
 
-// StrEqFold asserts expectation and value are equivalent, ignoring case.
-func StrEqFold(t T, expectation, value string, scripts ...PostScript) {
+// StrEqFold asserts exp and val are equivalent, ignoring case.
+func StrEqFold(t T, exp, val string, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.StrEqFold(expectation, value), scripts...)
+	invoke(t, assertions.StrEqFold(exp, val), scripts...)
 }
 
-// StrNotEqFold asserts expectation and value are not equivalent, ignoring case.
-func StrNotEqFold(t T, expectation, value string, scripts ...PostScript) {
+// StrNotEqFold asserts exp and val are not equivalent, ignoring case.
+func StrNotEqFold(t T, exp, val string, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.StrNotEqFold(expectation, value), scripts...)
+	invoke(t, assertions.StrNotEqFold(exp, val), scripts...)
 }
 
 // StrContains asserts s contains substring sub.

--- a/must/must_test.go
+++ b/must/must_test.go
@@ -472,7 +472,7 @@ func TestSliceEqual(t *testing.T) {
 }
 
 func TestLesser(t *testing.T) {
-	tc := newCase(t, `expected value to be less via .Less method`)
+	tc := newCase(t, `expected val to be less via .Less method`)
 	t.Cleanup(tc.assert)
 
 	a := &Person{ID: 200, Name: "Alice"}
@@ -629,14 +629,14 @@ func TestSliceContainsAll(t *testing.T) {
 }
 
 func TestPositive(t *testing.T) {
-	tc := newCase(t, `expected positive value`)
+	tc := newCase(t, `expected positive val`)
 	t.Cleanup(tc.assert)
 
 	Positive(tc, -1)
 }
 
 func TestNegative(t *testing.T) {
-	tc := newCase(t, `expected negative value`)
+	tc := newCase(t, `expected negative val`)
 	t.Cleanup(tc.assert)
 
 	Negative(tc, 1)
@@ -729,13 +729,13 @@ func TestGreaterEq(t *testing.T) {
 
 func TestBetween(t *testing.T) {
 	t.Run("too high", func(t *testing.T) {
-		tc := newCase(t, `expected value in range (3 ≤ value ≤ 5)`)
+		tc := newCase(t, `expected val in range (3 ≤ val ≤ 5)`)
 		t.Cleanup(tc.assert)
 		Between(tc, 3, 7, 5)
 	})
 
 	t.Run("too low", func(t *testing.T) {
-		tc := newCase(t, `expected value in range (3 ≤ value ≤ 5)`)
+		tc := newCase(t, `expected val in range (3 ≤ val ≤ 5)`)
 		t.Cleanup(tc.assert)
 		Between(tc, 3, 1, 5)
 	})
@@ -743,25 +743,25 @@ func TestBetween(t *testing.T) {
 
 func TestBetweenExclusive(t *testing.T) {
 	t.Run("too high", func(t *testing.T) {
-		tc := newCase(t, `expected value in range (3 < value < 5)`)
+		tc := newCase(t, `expected val in range (3 < val < 5)`)
 		t.Cleanup(tc.assert)
 		BetweenExclusive(tc, 3, 7, 5)
 	})
 
 	t.Run("too high fence", func(t *testing.T) {
-		tc := newCase(t, `expected value in range (3 < value < 5)`)
+		tc := newCase(t, `expected val in range (3 < val < 5)`)
 		t.Cleanup(tc.assert)
 		BetweenExclusive(tc, 3, 5, 5)
 	})
 
 	t.Run("too low", func(t *testing.T) {
-		tc := newCase(t, `expected value in range (3 < value < 5)`)
+		tc := newCase(t, `expected val in range (3 < val < 5)`)
 		t.Cleanup(tc.assert)
 		BetweenExclusive(tc, 3, 1, 5)
 	})
 
 	t.Run("too low fence", func(t *testing.T) {
-		tc := newCase(t, `expected value in range (3 < value < 5)`)
+		tc := newCase(t, `expected val in range (3 < val < 5)`)
 		t.Cleanup(tc.assert)
 		BetweenExclusive(tc, 3, 3, 5)
 	})
@@ -954,7 +954,7 @@ func TestMapEq(t *testing.T) {
 }
 
 func TestMapEqFunc(t *testing.T) {
-	t.Run("different value", func(t *testing.T) {
+	t.Run("different values", func(t *testing.T) {
 		tc := newCase(t, `expected maps of same values via 'eq' function`)
 		t.Cleanup(tc.assert)
 
@@ -975,7 +975,7 @@ func TestMapEqFunc(t *testing.T) {
 }
 
 func TestMapEqual(t *testing.T) {
-	t.Run("different value", func(t *testing.T) {
+	t.Run("different values", func(t *testing.T) {
 		tc := newCase(t, `expected maps of same values via .Equal method`)
 		t.Cleanup(tc.assert)
 

--- a/must/must_test.go
+++ b/must/must_test.go
@@ -472,13 +472,13 @@ func TestSliceEqual(t *testing.T) {
 }
 
 func TestLesser(t *testing.T) {
-	tc := newCase(t, `expected to be less via .Less method`)
+	tc := newCase(t, `expected value to be less via .Less method`)
 	t.Cleanup(tc.assert)
 
 	a := &Person{ID: 200, Name: "Alice"}
 	b := &Person{ID: 100, Name: "Bob"}
 
-	Lesser(tc, a, b)
+	Lesser(tc, b, a)
 }
 
 func TestLesser_PS(t *testing.T) {
@@ -488,7 +488,7 @@ func TestLesser_PS(t *testing.T) {
 	a := &Person{ID: 200, Name: "Alice"}
 	b := &Person{ID: 100, Name: "Bob"}
 
-	Lesser(tc, a, b, tc.PS("lesser"))
+	Lesser(tc, b, a, tc.PS("lesser"))
 }
 
 func TestSliceEmpty(t *testing.T) {
@@ -667,19 +667,19 @@ func TestLess(t *testing.T) {
 	t.Run("integers", func(t *testing.T) {
 		tc := newCase(t, `expected 7 < 5`)
 		t.Cleanup(tc.assert)
-		Less(tc, 7, 5)
+		Less(tc, 5, 7)
 	})
 
 	t.Run("floats", func(t *testing.T) {
-		tc := newCase(t, `expected 7.7 < 5.5`)
+		tc := newCase(t, `expected 7.5 < 5.5`)
 		t.Cleanup(tc.assert)
-		Less(tc, 7.7, 5.5)
+		Less(tc, 5.5, 7.5)
 	})
 
 	t.Run("strings", func(t *testing.T) {
 		tc := newCase(t, `expected foo < bar`)
 		t.Cleanup(tc.assert)
-		Less(tc, "foo", "bar")
+		Less(tc, "bar", "foo")
 	})
 
 	t.Run("equal", func(t *testing.T) {
@@ -690,28 +690,28 @@ func TestLess(t *testing.T) {
 }
 
 func TestLessEq(t *testing.T) {
-	tc := newCase(t, `expected 7 <= 5`)
+	tc := newCase(t, `expected 7 ≤ 5`)
 	t.Cleanup(tc.assert)
-	LessEq(tc, 7, 5)
+	LessEq(tc, 5, 7)
 }
 
 func TestGreater(t *testing.T) {
 	t.Run("integer", func(t *testing.T) {
 		tc := newCase(t, `expected 5 > 7`)
 		t.Cleanup(tc.assert)
-		Greater(tc, 5, 7)
+		Greater(tc, 7, 5)
 	})
 
 	t.Run("floats", func(t *testing.T) {
 		tc := newCase(t, `expected 5.5 > 7.7`)
 		t.Cleanup(tc.assert)
-		Greater(tc, 5.5, 7.7)
+		Greater(tc, 7.7, 5.5)
 	})
 
 	t.Run("strings", func(t *testing.T) {
 		tc := newCase(t, `expected bar > foo`)
 		t.Cleanup(tc.assert)
-		Greater(tc, "bar", "foo")
+		Greater(tc, "foo", "bar")
 	})
 
 	t.Run("equal", func(t *testing.T) {
@@ -722,9 +722,9 @@ func TestGreater(t *testing.T) {
 }
 
 func TestGreaterEq(t *testing.T) {
-	tc := newCase(t, `expected 5 >= 7`)
+	tc := newCase(t, `expected 5 ≥ 7`)
 	t.Cleanup(tc.assert)
-	GreaterEq(tc, 5, 7)
+	GreaterEq(tc, 7, 5)
 }
 
 func TestBetween(t *testing.T) {

--- a/must/scripts.go
+++ b/must/scripts.go
@@ -59,16 +59,16 @@ func Sprint(args ...any) PostScript {
 	}
 }
 
-// Values adds formatted key-value mappings as an annotation to the output of a test case failure.
-func Values(values ...any) PostScript {
+// Values adds formatted key-val mappings as an annotation to the output of a test case failure.
+func Values(vals ...any) PostScript {
 	b := new(strings.Builder)
-	n := len(values)
+	n := len(vals)
 	for i := 0; i < n-1; i += 2 {
-		s := fmt.Sprintf("\t%#v => %#v\n", values[i], values[i+1])
+		s := fmt.Sprintf("\t%#v => %#v\n", vals[i], vals[i+1])
 		b.WriteString(s)
 	}
 	if n%2 != 0 {
-		s := fmt.Sprintf("\t%v => <MISSING ARG>", values[n-1])
+		s := fmt.Sprintf("\t%v => <MISSING ARG>", vals[n-1])
 		b.WriteString(s)
 	}
 	return &script{

--- a/scripts.go
+++ b/scripts.go
@@ -57,16 +57,16 @@ func Sprint(args ...any) PostScript {
 	}
 }
 
-// Values adds formatted key-value mappings as an annotation to the output of a test case failure.
-func Values(values ...any) PostScript {
+// Values adds formatted key-val mappings as an annotation to the output of a test case failure.
+func Values(vals ...any) PostScript {
 	b := new(strings.Builder)
-	n := len(values)
+	n := len(vals)
 	for i := 0; i < n-1; i += 2 {
-		s := fmt.Sprintf("\t%#v => %#v\n", values[i], values[i+1])
+		s := fmt.Sprintf("\t%#v => %#v\n", vals[i], vals[i+1])
 		b.WriteString(s)
 	}
 	if n%2 != 0 {
-		s := fmt.Sprintf("\t%v => <MISSING ARG>", values[n-1])
+		s := fmt.Sprintf("\t%v => <MISSING ARG>", vals[n-1])
 		b.WriteString(s)
 	}
 	return &script{

--- a/test.go
+++ b/test.go
@@ -65,76 +65,76 @@ func NoError(t T, err error, scripts ...PostScript) {
 	invoke(t, assertions.NoError(err), scripts...)
 }
 
-// Eq asserts expectation and value are equal using cmp.Equal.
-func Eq[A any](t T, expectation, value A, scripts ...PostScript) {
+// Eq asserts exp and val are equal using cmp.Equal.
+func Eq[A any](t T, exp, val A, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.Eq(expectation, value), scripts...)
+	invoke(t, assertions.Eq(exp, val), scripts...)
 }
 
-// EqOp asserts expectation == value.
-func EqOp[C comparable](t T, expectation, value C, scripts ...PostScript) {
+// EqOp asserts exp == val.
+func EqOp[C comparable](t T, exp, val C, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.EqOp(expectation, value), scripts...)
+	invoke(t, assertions.EqOp(exp, val), scripts...)
 }
 
-// EqFunc asserts expectation and value are equal using eq.
-func EqFunc[A any](t T, expectation, value A, eq func(a, b A) bool, scripts ...PostScript) {
+// EqFunc asserts exp and val are equal using eq.
+func EqFunc[A any](t T, exp, val A, eq func(a, b A) bool, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.EqFunc(expectation, value, eq), scripts...)
+	invoke(t, assertions.EqFunc(exp, val, eq), scripts...)
 }
 
-// NotEq asserts expectation and value are not equal using cmp.Equal.
-func NotEq[A any](t T, expectation, value A, scripts ...PostScript) {
+// NotEq asserts exp and val are not equal using cmp.Equal.
+func NotEq[A any](t T, exp, val A, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.NotEq(expectation, value), scripts...)
+	invoke(t, assertions.NotEq(exp, val), scripts...)
 }
 
-// NotEqOp asserts expectation != value.
-func NotEqOp[C comparable](t T, expectation, value C, scripts ...PostScript) {
+// NotEqOp asserts exp != val.
+func NotEqOp[C comparable](t T, exp, val C, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.NotEqOp(expectation, value), scripts...)
+	invoke(t, assertions.NotEqOp(exp, val), scripts...)
 }
 
-// NotEqFunc asserts expectation and value are not equal using eq.
-func NotEqFunc[A any](t T, expectation, value A, eq func(a, b A) bool, scripts ...PostScript) {
+// NotEqFunc asserts exp and val are not equal using eq.
+func NotEqFunc[A any](t T, exp, val A, eq func(a, b A) bool, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.NotEqFunc(expectation, value, eq), scripts...)
+	invoke(t, assertions.NotEqFunc(exp, val, eq), scripts...)
 }
 
-// EqJSON asserts expectation and value are equivalent JSON.
-func EqJSON(t T, expectation, value string, scripts ...PostScript) {
+// EqJSON asserts exp and val are equivalent JSON.
+func EqJSON(t T, exp, val string, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.EqJSON(expectation, value), scripts...)
+	invoke(t, assertions.EqJSON(exp, val), scripts...)
 }
 
-// Equal asserts value.Equal(expectation).
-func Equal[E interfaces.EqualFunc[E]](t T, expectation, value E, scripts ...PostScript) {
+// Equal asserts val.Equal(exp).
+func Equal[E interfaces.EqualFunc[E]](t T, exp, val E, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.Equal(expectation, value), scripts...)
+	invoke(t, assertions.Equal(exp, val), scripts...)
 }
 
-// NotEqual asserts !value.Equal(expectation).
-func NotEqual[E interfaces.EqualFunc[E]](t T, expectation, value E, scripts ...PostScript) {
+// NotEqual asserts !val.Equal(exp).
+func NotEqual[E interfaces.EqualFunc[E]](t T, exp, val E, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.NotEqual(expectation, value), scripts...)
+	invoke(t, assertions.NotEqual(exp, val), scripts...)
 }
 
-// Lesser asserts value.Less(expectation).
-func Lesser[L interfaces.LessFunc[L]](t T, expectation, value L, scripts ...PostScript) {
+// Lesser asserts val.Less(exp).
+func Lesser[L interfaces.LessFunc[L]](t T, exp, val L, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.Lesser(expectation, value), scripts...)
+	invoke(t, assertions.Lesser(exp, val), scripts...)
 }
 
-// SliceEqFunc asserts elements of expectation and value are the same using eq.
-func SliceEqFunc[A any](t T, expectation, value []A, eq func(a, b A) bool, scripts ...PostScript) {
+// SliceEqFunc asserts elements of exp and val are the same using eq.
+func SliceEqFunc[A any](t T, exp, val []A, eq func(a, b A) bool, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.EqSliceFunc(expectation, value, eq), scripts...)
+	invoke(t, assertions.EqSliceFunc(exp, val, eq), scripts...)
 }
 
-// SliceEqual asserts value[n].Equal(expectation[n]) for each element n.
-func SliceEqual[E interfaces.EqualFunc[E]](t T, expectation, value []E, scripts ...PostScript) {
+// SliceEqual asserts val[n].Equal(exp[n]) for each element n.
+func SliceEqual[E interfaces.EqualFunc[E]](t T, exp, val []E, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.SliceEqual(expectation, value), scripts...)
+	invoke(t, assertions.SliceEqual(exp, val), scripts...)
 }
 
 // SliceEmpty asserts slice is empty.
@@ -229,40 +229,40 @@ func One[N interfaces.Number](t T, n N, scripts ...PostScript) {
 	invoke(t, assertions.One(n), scripts...)
 }
 
-// Less asserts value < expectation.
-func Less[O constraints.Ordered](t T, expectation, value O, scripts ...PostScript) {
+// Less asserts val < exp.
+func Less[O constraints.Ordered](t T, exp, val O, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.Less(expectation, value), scripts...)
+	invoke(t, assertions.Less(exp, val), scripts...)
 }
 
-// LessEq asserts value ≤ expectation.
-func LessEq[O constraints.Ordered](t T, expectation, value O, scripts ...PostScript) {
+// LessEq asserts val ≤ exp.
+func LessEq[O constraints.Ordered](t T, exp, val O, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.LessEq(expectation, value), scripts...)
+	invoke(t, assertions.LessEq(exp, val), scripts...)
 }
 
-// Greater asserts value > expectation.
-func Greater[O constraints.Ordered](t T, expectation, value O, scripts ...PostScript) {
+// Greater asserts val > exp.
+func Greater[O constraints.Ordered](t T, exp, val O, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.Greater(expectation, value), scripts...)
+	invoke(t, assertions.Greater(exp, val), scripts...)
 }
 
-// GreaterEq asserts value ≥ expectation.
-func GreaterEq[O constraints.Ordered](t T, expectation, value O, scripts ...PostScript) {
+// GreaterEq asserts val ≥ exp.
+func GreaterEq[O constraints.Ordered](t T, exp, val O, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.GreaterEq(expectation, value), scripts...)
+	invoke(t, assertions.GreaterEq(exp, val), scripts...)
 }
 
-// Between asserts lower ≤ value ≤ upper.
-func Between[O constraints.Ordered](t T, lower, value, upper O, scripts ...PostScript) {
+// Between asserts lower ≤ val ≤ upper.
+func Between[O constraints.Ordered](t T, lower, val, upper O, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.Between(lower, value, upper), scripts...)
+	invoke(t, assertions.Between(lower, val, upper), scripts...)
 }
 
-// BetweenExclusive asserts lower < value < upper.
-func BetweenExclusive[O constraints.Ordered](t T, lower, value, upper O, scripts ...PostScript) {
+// BetweenExclusive asserts lower < val < upper.
+func BetweenExclusive[O constraints.Ordered](t T, lower, val, upper O, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.BetweenExclusive(lower, value, upper), scripts...)
+	invoke(t, assertions.BetweenExclusive(lower, val, upper), scripts...)
 }
 
 // Ascending asserts slice[n] ≤ slice[n+1] for each element n.
@@ -313,25 +313,25 @@ func InDeltaSlice[N interfaces.Number](t T, a, b []N, delta N, scripts ...PostSc
 	invoke(t, assertions.InDeltaSlice(a, b, delta), scripts...)
 }
 
-// MapEq asserts maps expectation and value contain the same key/value pairs, using
-// cmp.Equal function to compare values.
-func MapEq[M1, M2 interfaces.Map[K, V], K comparable, V any](t T, expectation M1, value M2, scripts ...PostScript) {
+// MapEq asserts maps exp and val contain the same key/val pairs, using
+// cmp.Equal function to compare vals.
+func MapEq[M1, M2 interfaces.Map[K, V], K comparable, V any](t T, exp M1, val M2, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.MapEq[M1, M2, K, V](expectation, value), scripts...)
+	invoke(t, assertions.MapEq[M1, M2, K, V](exp, val), scripts...)
 }
 
-// MapEqFunc asserts maps expectation and value contain the same key/value pairs, using eq to
-// compare values.
-func MapEqFunc[M1, M2 interfaces.Map[K, V], K comparable, V any](t T, expectation M1, value M2, eq func(V, V) bool, scripts ...PostScript) {
+// MapEqFunc asserts maps exp and val contain the same key/val pairs, using eq to
+// compare vals.
+func MapEqFunc[M1, M2 interfaces.Map[K, V], K comparable, V any](t T, exp M1, val M2, eq func(V, V) bool, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.MapEqFunc[M1, M2, K, V](expectation, value, eq), scripts...)
+	invoke(t, assertions.MapEqFunc[M1, M2, K, V](exp, val, eq), scripts...)
 }
 
-// MapEqual asserts maps expectation and value contain the same key/value pairs, using Equal
-// method to compare values
-func MapEqual[M interfaces.MapEqualFunc[K, V], K comparable, V interfaces.EqualFunc[V]](t T, expectation, value M, scripts ...PostScript) {
+// MapEqual asserts maps exp and val contain the same key/val pairs, using Equal
+// method to compare vals
+func MapEqual[M interfaces.MapEqualFunc[K, V], K comparable, V interfaces.EqualFunc[V]](t T, exp, val M, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.MapEqual[M, K, V](expectation, value), scripts...)
+	invoke(t, assertions.MapEqual[M, K, V](exp, val), scripts...)
 }
 
 // MapLen asserts map is of size n.
@@ -358,21 +358,21 @@ func MapContainsKeys[M ~map[K]V, K comparable, V any](t T, m M, keys []K, script
 	invoke(t, assertions.MapContainsKeys[M, K, V](m, keys), scripts...)
 }
 
-// MapContainsValues asserts m contains each value in values.
-func MapContainsValues[M ~map[K]V, K comparable, V any](t T, m M, values []V, scripts ...PostScript) {
+// MapContainsValues asserts m contains each val in vals.
+func MapContainsValues[M ~map[K]V, K comparable, V any](t T, m M, vals []V, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.MapContainsValues[M, K, V](m, values), scripts...)
+	invoke(t, assertions.MapContainsValues[M, K, V](m, vals), scripts...)
 }
 
-// MapContainsValuesFunc asserts m contains each value in values using the eq function.
-func MapContainsValuesFunc[M ~map[K]V, K comparable, V any](t T, m M, values []V, eq func(V, V) bool, scripts ...PostScript) {
+// MapContainsValuesFunc asserts m contains each val in vals using the eq function.
+func MapContainsValuesFunc[M ~map[K]V, K comparable, V any](t T, m M, vals []V, eq func(V, V) bool, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.MapContainsValuesFunc[M, K, V](m, values, eq), scripts...)
+	invoke(t, assertions.MapContainsValuesFunc[M, K, V](m, vals, eq), scripts...)
 }
 
-func MapContainsValuesEqual[M ~map[K]V, K comparable, V interfaces.EqualFunc[V]](t T, m M, values []V, scripts ...PostScript) {
+func MapContainsValuesEqual[M ~map[K]V, K comparable, V interfaces.EqualFunc[V]](t T, m M, vals []V, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.MapContainsValuesEqual[M, K, V](m, values), scripts...)
+	invoke(t, assertions.MapContainsValuesEqual[M, K, V](m, vals), scripts...)
 }
 
 // FileExistsFS asserts file exists on the fs.FS filesystem.
@@ -477,16 +477,16 @@ func FilePathValid(t T, path string, scripts ...PostScript) {
 	invoke(t, assertions.FilePathValid(path), scripts...)
 }
 
-// StrEqFold asserts expectation and value are equivalent, ignoring case.
-func StrEqFold(t T, expectation, value string, scripts ...PostScript) {
+// StrEqFold asserts exp and val are equivalent, ignoring case.
+func StrEqFold(t T, exp, val string, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.StrEqFold(expectation, value), scripts...)
+	invoke(t, assertions.StrEqFold(exp, val), scripts...)
 }
 
-// StrNotEqFold asserts expectation and value are not equivalent, ignoring case.
-func StrNotEqFold(t T, expectation, value string, scripts ...PostScript) {
+// StrNotEqFold asserts exp and val are not equivalent, ignoring case.
+func StrNotEqFold(t T, exp, val string, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.StrNotEqFold(expectation, value), scripts...)
+	invoke(t, assertions.StrNotEqFold(exp, val), scripts...)
 }
 
 // StrContains asserts s contains substring sub.

--- a/test.go
+++ b/test.go
@@ -65,76 +65,76 @@ func NoError(t T, err error, scripts ...PostScript) {
 	invoke(t, assertions.NoError(err), scripts...)
 }
 
-// Eq asserts a and b are equal using cmp.Equal.
-func Eq[A any](t T, a, b A, scripts ...PostScript) {
+// Eq asserts expectation and value are equal using cmp.Equal.
+func Eq[A any](t T, expectation, value A, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.Eq(a, b), scripts...)
+	invoke(t, assertions.Eq(expectation, value), scripts...)
 }
 
-// EqOp asserts a == b.
-func EqOp[C comparable](t T, a, b C, scripts ...PostScript) {
+// EqOp asserts expectation == value.
+func EqOp[C comparable](t T, expectation, value C, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.EqOp(a, b), scripts...)
+	invoke(t, assertions.EqOp(expectation, value), scripts...)
 }
 
-// EqFunc asserts a and b are equal using eq.
-func EqFunc[A any](t T, a, b A, eq func(a, b A) bool, scripts ...PostScript) {
+// EqFunc asserts expectation and value are equal using eq.
+func EqFunc[A any](t T, expectation, value A, eq func(a, b A) bool, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.EqFunc(a, b, eq), scripts...)
+	invoke(t, assertions.EqFunc(expectation, value, eq), scripts...)
 }
 
-// NotEq asserts a and b are not equal using cmp.Equal.
-func NotEq[A any](t T, a, b A, scripts ...PostScript) {
+// NotEq asserts expectation and value are not equal using cmp.Equal.
+func NotEq[A any](t T, expectation, value A, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.NotEq(a, b), scripts...)
+	invoke(t, assertions.NotEq(expectation, value), scripts...)
 }
 
-// NotEqOp asserts a != b.
-func NotEqOp[C comparable](t T, a, b C, scripts ...PostScript) {
+// NotEqOp asserts expectation != value.
+func NotEqOp[C comparable](t T, expectation, value C, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.NotEqOp(a, b), scripts...)
+	invoke(t, assertions.NotEqOp(expectation, value), scripts...)
 }
 
-// NotEqFunc asserts a and b are not equal using eq.
-func NotEqFunc[A any](t T, a, b A, eq func(a, b A) bool, scripts ...PostScript) {
+// NotEqFunc asserts expectation and value are not equal using eq.
+func NotEqFunc[A any](t T, expectation, value A, eq func(a, b A) bool, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.NotEqFunc(a, b, eq), scripts...)
+	invoke(t, assertions.NotEqFunc(expectation, value, eq), scripts...)
 }
 
-// EqJSON asserts a and b are equivalent JSON.
-func EqJSON(t T, a, b string, scripts ...PostScript) {
+// EqJSON asserts expectation and value are equivalent JSON.
+func EqJSON(t T, expectation, value string, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.EqJSON(a, b), scripts...)
+	invoke(t, assertions.EqJSON(expectation, value), scripts...)
 }
 
-// SliceEqFunc asserts elements of a and b are the same using eq.
-func SliceEqFunc[A any](t T, a, b []A, eq func(a, b A) bool, scripts ...PostScript) {
+// Equal asserts value.Equal(expectation).
+func Equal[E interfaces.EqualFunc[E]](t T, expectation, value E, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.EqSliceFunc(a, b, eq), scripts...)
+	invoke(t, assertions.Equal(expectation, value), scripts...)
 }
 
-// Equal asserts a.Equal(b).
-func Equal[E interfaces.EqualFunc[E]](t T, a, b E, scripts ...PostScript) {
+// NotEqual asserts !value.Equal(expectation).
+func NotEqual[E interfaces.EqualFunc[E]](t T, expectation, value E, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.Equal(a, b), scripts...)
+	invoke(t, assertions.NotEqual(expectation, value), scripts...)
 }
 
-// NotEqual asserts !a.Equal(b).
-func NotEqual[E interfaces.EqualFunc[E]](t T, a, b E, scripts ...PostScript) {
+// Lesser asserts value.Less(expectation).
+func Lesser[L interfaces.LessFunc[L]](t T, expectation, value L, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.NotEqual(a, b), scripts...)
+	invoke(t, assertions.Lesser(expectation, value), scripts...)
 }
 
-// Lesser asserts a.Less(b).
-func Lesser[L interfaces.LessFunc[L]](t T, a, b L, scripts ...PostScript) {
+// SliceEqFunc asserts elements of expectation and value are the same using eq.
+func SliceEqFunc[A any](t T, expectation, value []A, eq func(a, b A) bool, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.Lesser(a, b), scripts...)
+	invoke(t, assertions.EqSliceFunc(expectation, value, eq), scripts...)
 }
 
-// SliceEqual asserts a[n].Equal(b[n]) for each element n in slices a and b.
-func SliceEqual[E interfaces.EqualFunc[E]](t T, a, b []E, scripts ...PostScript) {
+// SliceEqual asserts value[n].Equal(expectation[n]) for each element n.
+func SliceEqual[E interfaces.EqualFunc[E]](t T, expectation, value []E, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.SliceEqual(a, b), scripts...)
+	invoke(t, assertions.SliceEqual(expectation, value), scripts...)
 }
 
 // SliceEmpty asserts slice is empty.
@@ -229,28 +229,28 @@ func One[N interfaces.Number](t T, n N, scripts ...PostScript) {
 	invoke(t, assertions.One(n), scripts...)
 }
 
-// Less asserts a < b.
-func Less[O constraints.Ordered](t T, a, b O, scripts ...PostScript) {
+// Less asserts value < expectation.
+func Less[O constraints.Ordered](t T, expectation, value O, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.Less(a, b), scripts...)
+	invoke(t, assertions.Less(expectation, value), scripts...)
 }
 
-// LessEq asserts a <= b.
-func LessEq[O constraints.Ordered](t T, a, b O, scripts ...PostScript) {
+// LessEq asserts value ≤ expectation.
+func LessEq[O constraints.Ordered](t T, expectation, value O, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.LessEq(a, b), scripts...)
+	invoke(t, assertions.LessEq(expectation, value), scripts...)
 }
 
-// Greater asserts a > b.
-func Greater[O constraints.Ordered](t T, a, b O, scripts ...PostScript) {
+// Greater asserts value > expectation.
+func Greater[O constraints.Ordered](t T, expectation, value O, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.Greater(a, b), scripts...)
+	invoke(t, assertions.Greater(expectation, value), scripts...)
 }
 
-// GreaterEq asserts a >= b.
-func GreaterEq[O constraints.Ordered](t T, a, b O, scripts ...PostScript) {
+// GreaterEq asserts value ≥ expectation.
+func GreaterEq[O constraints.Ordered](t T, expectation, value O, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.GreaterEq(a, b), scripts...)
+	invoke(t, assertions.GreaterEq(expectation, value), scripts...)
 }
 
 // Between asserts lower ≤ value ≤ upper.
@@ -265,7 +265,7 @@ func BetweenExclusive[O constraints.Ordered](t T, lower, value, upper O, scripts
 	invoke(t, assertions.BetweenExclusive(lower, value, upper), scripts...)
 }
 
-// Ascending asserts slice[n] <= slice[n+1] for each element n.
+// Ascending asserts slice[n] ≤ slice[n+1] for each element n.
 func Ascending[O constraints.Ordered](t T, slice []O, scripts ...PostScript) {
 	t.Helper()
 	invoke(t, assertions.Ascending(slice), scripts...)
@@ -283,7 +283,7 @@ func AscendingLess[L interfaces.LessFunc[L]](t T, slice []L, scripts ...PostScri
 	invoke(t, assertions.AscendingLess(slice), scripts...)
 }
 
-// Descending asserts slice[n] >= slice[n+1] for each element n.
+// Descending asserts slice[n] ≥ slice[n+1] for each element n.
 func Descending[O constraints.Ordered](t T, slice []O, scripts ...PostScript) {
 	t.Helper()
 	invoke(t, assertions.Descending(slice), scripts...)
@@ -313,25 +313,25 @@ func InDeltaSlice[N interfaces.Number](t T, a, b []N, delta N, scripts ...PostSc
 	invoke(t, assertions.InDeltaSlice(a, b, delta), scripts...)
 }
 
-// MapEq asserts maps a and b contain the same key/value pairs, using
+// MapEq asserts maps expectation and value contain the same key/value pairs, using
 // cmp.Equal function to compare values.
-func MapEq[M1, M2 interfaces.Map[K, V], K comparable, V any](t T, a M1, b M2, scripts ...PostScript) {
+func MapEq[M1, M2 interfaces.Map[K, V], K comparable, V any](t T, expectation M1, value M2, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.MapEq[M1, M2, K, V](a, b), scripts...)
+	invoke(t, assertions.MapEq[M1, M2, K, V](expectation, value), scripts...)
 }
 
-// MapEqFunc asserts maps a and b contain the same key/value pairs, using eq to
+// MapEqFunc asserts maps expectation and value contain the same key/value pairs, using eq to
 // compare values.
-func MapEqFunc[M1, M2 interfaces.Map[K, V], K comparable, V any](t T, a M1, b M2, eq func(V, V) bool, scripts ...PostScript) {
+func MapEqFunc[M1, M2 interfaces.Map[K, V], K comparable, V any](t T, expectation M1, value M2, eq func(V, V) bool, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.MapEqFunc[M1, M2, K, V](a, b, eq), scripts...)
+	invoke(t, assertions.MapEqFunc[M1, M2, K, V](expectation, value, eq), scripts...)
 }
 
-// MapEqual asserts maps a and b contain the same key/value pairs, using Equal
+// MapEqual asserts maps expectation and value contain the same key/value pairs, using Equal
 // method to compare values
-func MapEqual[M interfaces.MapEqualFunc[K, V], K comparable, V interfaces.EqualFunc[V]](t T, a, b M, scripts ...PostScript) {
+func MapEqual[M interfaces.MapEqualFunc[K, V], K comparable, V interfaces.EqualFunc[V]](t T, expectation, value M, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.MapEqual[M, K, V](a, b), scripts...)
+	invoke(t, assertions.MapEqual[M, K, V](expectation, value), scripts...)
 }
 
 // MapLen asserts map is of size n.
@@ -477,16 +477,16 @@ func FilePathValid(t T, path string, scripts ...PostScript) {
 	invoke(t, assertions.FilePathValid(path), scripts...)
 }
 
-// StrEqFold asserts first and second are equivalent, ignoring case.
-func StrEqFold(t T, first, second string, scripts ...PostScript) {
+// StrEqFold asserts expectation and value are equivalent, ignoring case.
+func StrEqFold(t T, expectation, value string, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.StrEqFold(first, second), scripts...)
+	invoke(t, assertions.StrEqFold(expectation, value), scripts...)
 }
 
-// StrNotEqFold asserts first and second are not equivalent, ignoring case.
-func StrNotEqFold(t T, first, second string, scripts ...PostScript) {
+// StrNotEqFold asserts expectation and value are not equivalent, ignoring case.
+func StrNotEqFold(t T, expectation, value string, scripts ...PostScript) {
 	t.Helper()
-	invoke(t, assertions.StrNotEqFold(first, second), scripts...)
+	invoke(t, assertions.StrNotEqFold(expectation, value), scripts...)
 }
 
 // StrContains asserts s contains substring sub.

--- a/test_test.go
+++ b/test_test.go
@@ -470,7 +470,7 @@ func TestSliceEqual(t *testing.T) {
 }
 
 func TestLesser(t *testing.T) {
-	tc := newCase(t, `expected value to be less via .Less method`)
+	tc := newCase(t, `expected val to be less via .Less method`)
 	t.Cleanup(tc.assert)
 
 	a := &Person{ID: 200, Name: "Alice"}
@@ -627,14 +627,14 @@ func TestSliceContainsAll(t *testing.T) {
 }
 
 func TestPositive(t *testing.T) {
-	tc := newCase(t, `expected positive value`)
+	tc := newCase(t, `expected positive val`)
 	t.Cleanup(tc.assert)
 
 	Positive(tc, -1)
 }
 
 func TestNegative(t *testing.T) {
-	tc := newCase(t, `expected negative value`)
+	tc := newCase(t, `expected negative val`)
 	t.Cleanup(tc.assert)
 
 	Negative(tc, 1)
@@ -727,13 +727,13 @@ func TestGreaterEq(t *testing.T) {
 
 func TestBetween(t *testing.T) {
 	t.Run("too high", func(t *testing.T) {
-		tc := newCase(t, `expected value in range (3 ≤ value ≤ 5)`)
+		tc := newCase(t, `expected val in range (3 ≤ val ≤ 5)`)
 		t.Cleanup(tc.assert)
 		Between(tc, 3, 7, 5)
 	})
 
 	t.Run("too low", func(t *testing.T) {
-		tc := newCase(t, `expected value in range (3 ≤ value ≤ 5)`)
+		tc := newCase(t, `expected val in range (3 ≤ val ≤ 5)`)
 		t.Cleanup(tc.assert)
 		Between(tc, 3, 1, 5)
 	})
@@ -741,25 +741,25 @@ func TestBetween(t *testing.T) {
 
 func TestBetweenExclusive(t *testing.T) {
 	t.Run("too high", func(t *testing.T) {
-		tc := newCase(t, `expected value in range (3 < value < 5)`)
+		tc := newCase(t, `expected val in range (3 < val < 5)`)
 		t.Cleanup(tc.assert)
 		BetweenExclusive(tc, 3, 7, 5)
 	})
 
 	t.Run("too high fence", func(t *testing.T) {
-		tc := newCase(t, `expected value in range (3 < value < 5)`)
+		tc := newCase(t, `expected val in range (3 < val < 5)`)
 		t.Cleanup(tc.assert)
 		BetweenExclusive(tc, 3, 5, 5)
 	})
 
 	t.Run("too low", func(t *testing.T) {
-		tc := newCase(t, `expected value in range (3 < value < 5)`)
+		tc := newCase(t, `expected val in range (3 < val < 5)`)
 		t.Cleanup(tc.assert)
 		BetweenExclusive(tc, 3, 1, 5)
 	})
 
 	t.Run("too low fence", func(t *testing.T) {
-		tc := newCase(t, `expected value in range (3 < value < 5)`)
+		tc := newCase(t, `expected val in range (3 < val < 5)`)
 		t.Cleanup(tc.assert)
 		BetweenExclusive(tc, 3, 3, 5)
 	})
@@ -952,7 +952,7 @@ func TestMapEq(t *testing.T) {
 }
 
 func TestMapEqFunc(t *testing.T) {
-	t.Run("different value", func(t *testing.T) {
+	t.Run("different values", func(t *testing.T) {
 		tc := newCase(t, `expected maps of same values via 'eq' function`)
 		t.Cleanup(tc.assert)
 
@@ -973,7 +973,7 @@ func TestMapEqFunc(t *testing.T) {
 }
 
 func TestMapEqual(t *testing.T) {
-	t.Run("different value", func(t *testing.T) {
+	t.Run("different values", func(t *testing.T) {
 		tc := newCase(t, `expected maps of same values via .Equal method`)
 		t.Cleanup(tc.assert)
 

--- a/test_test.go
+++ b/test_test.go
@@ -470,13 +470,13 @@ func TestSliceEqual(t *testing.T) {
 }
 
 func TestLesser(t *testing.T) {
-	tc := newCase(t, `expected to be less via .Less method`)
+	tc := newCase(t, `expected value to be less via .Less method`)
 	t.Cleanup(tc.assert)
 
 	a := &Person{ID: 200, Name: "Alice"}
 	b := &Person{ID: 100, Name: "Bob"}
 
-	Lesser(tc, a, b)
+	Lesser(tc, b, a)
 }
 
 func TestLesser_PS(t *testing.T) {
@@ -486,7 +486,7 @@ func TestLesser_PS(t *testing.T) {
 	a := &Person{ID: 200, Name: "Alice"}
 	b := &Person{ID: 100, Name: "Bob"}
 
-	Lesser(tc, a, b, tc.PS("lesser"))
+	Lesser(tc, b, a, tc.PS("lesser"))
 }
 
 func TestSliceEmpty(t *testing.T) {
@@ -665,19 +665,19 @@ func TestLess(t *testing.T) {
 	t.Run("integers", func(t *testing.T) {
 		tc := newCase(t, `expected 7 < 5`)
 		t.Cleanup(tc.assert)
-		Less(tc, 7, 5)
+		Less(tc, 5, 7)
 	})
 
 	t.Run("floats", func(t *testing.T) {
-		tc := newCase(t, `expected 7.7 < 5.5`)
+		tc := newCase(t, `expected 7.5 < 5.5`)
 		t.Cleanup(tc.assert)
-		Less(tc, 7.7, 5.5)
+		Less(tc, 5.5, 7.5)
 	})
 
 	t.Run("strings", func(t *testing.T) {
 		tc := newCase(t, `expected foo < bar`)
 		t.Cleanup(tc.assert)
-		Less(tc, "foo", "bar")
+		Less(tc, "bar", "foo")
 	})
 
 	t.Run("equal", func(t *testing.T) {
@@ -688,28 +688,28 @@ func TestLess(t *testing.T) {
 }
 
 func TestLessEq(t *testing.T) {
-	tc := newCase(t, `expected 7 <= 5`)
+	tc := newCase(t, `expected 7 ≤ 5`)
 	t.Cleanup(tc.assert)
-	LessEq(tc, 7, 5)
+	LessEq(tc, 5, 7)
 }
 
 func TestGreater(t *testing.T) {
 	t.Run("integer", func(t *testing.T) {
 		tc := newCase(t, `expected 5 > 7`)
 		t.Cleanup(tc.assert)
-		Greater(tc, 5, 7)
+		Greater(tc, 7, 5)
 	})
 
 	t.Run("floats", func(t *testing.T) {
 		tc := newCase(t, `expected 5.5 > 7.7`)
 		t.Cleanup(tc.assert)
-		Greater(tc, 5.5, 7.7)
+		Greater(tc, 7.7, 5.5)
 	})
 
 	t.Run("strings", func(t *testing.T) {
 		tc := newCase(t, `expected bar > foo`)
 		t.Cleanup(tc.assert)
-		Greater(tc, "bar", "foo")
+		Greater(tc, "foo", "bar")
 	})
 
 	t.Run("equal", func(t *testing.T) {
@@ -720,9 +720,9 @@ func TestGreater(t *testing.T) {
 }
 
 func TestGreaterEq(t *testing.T) {
-	tc := newCase(t, `expected 5 >= 7`)
+	tc := newCase(t, `expected 5 ≥ 7`)
 	t.Cleanup(tc.assert)
-	GreaterEq(tc, 5, 7)
+	GreaterEq(tc, 7, 5)
 }
 
 func TestBetween(t *testing.T) {


### PR DESCRIPTION
This PR introduces breaking changes, where less/greater helpers now
have the expectation come first. This is to be more consistent with
other functions.

Closes https://github.com/shoenig/test/issues/33