### PR TITLE
slices: fix slice set comparisons

### DIFF
--- a/internal/assertions/assertions.go
+++ b/internal/assertions/assertions.go
@@ -378,6 +378,16 @@ func SliceNotContains[A any](slice []A, item A) (s string) {
 }
 
 func SliceContainsAll[A any](slice, items []A) (s string) {
+	if len(slice) != len(items) {
+		s = "expected slice and items to contain same number of elements\n"
+		s += fmt.Sprintf("↪ len(slice): %d\n", len(slice))
+		s += fmt.Sprintf("↪ len(items): %d\n", len(slice))
+		return s
+	}
+	return SliceContainsSubset(slice, items)
+}
+
+func SliceContainsSubset[A any](slice, items []A) (s string) {
 OUTER:
 	for _, target := range items {
 		var item A

--- a/must/must.go
+++ b/must/must.go
@@ -190,15 +190,26 @@ func SliceContains[A any](t T, slice []A, item A, scripts ...PostScript) {
 	invoke(t, assertions.SliceContains(slice, item), scripts...)
 }
 
+// SliceNotContains asserts item does not exist in slice, using cmp.Equal to
+// compare elements.
 func SliceNotContains[A any](t T, slice []A, item A, scripts ...PostScript) {
 	t.Helper()
 	invoke(t, assertions.SliceNotContains(slice, item), scripts...)
 }
 
-// SliceContainsAll asserts each item in items is contained in slice.
+// SliceContainsAll asserts slice and items contain the same elements, but in
+// no particular order. The number of elements in slice and items must be the
+// same.
 func SliceContainsAll[A any](t T, slice, items []A, scripts ...PostScript) {
 	t.Helper()
 	invoke(t, assertions.SliceContainsAll(slice, items), scripts...)
+}
+
+// SliceContainsSubset asserts slice contains each item in items, in no particular
+// order. There could be additional elements in slice not in items.
+func SliceContainsSubset[A any](t T, slice, items []A, scripts ...PostScript) {
+	t.Helper()
+	invoke(t, assertions.SliceContainsSubset(slice, items), scripts...)
 }
 
 // Positive asserts n > 0.

--- a/must/must_test.go
+++ b/must/must_test.go
@@ -615,6 +615,38 @@ func TestSliceNotContains(t *testing.T) {
 }
 
 func TestSliceContainsAll(t *testing.T) {
+	t.Run("wrong element", func(t *testing.T) {
+		tc := newCase(t, `expected slice to contain missing item`)
+		s := []*Person{
+			{ID: 100, Name: "Alice"},
+			{ID: 101, Name: "Bob"},
+		}
+		SliceContainsAll(tc, s, []*Person{{ID: 101, Name: "Bob"}, {ID: 105, Name: "Eve"}})
+		t.Cleanup(tc.assert)
+	})
+
+	t.Run("too large", func(t *testing.T) {
+		tc := newCase(t, `expected slice and items to contain same number of elements`)
+		s := []*Person{
+			{ID: 100, Name: "Alice"},
+			{ID: 101, Name: "Bob"},
+			{ID: 102, Name: "Carl"},
+		}
+		SliceContainsAll(tc, s, []*Person{{ID: 101, Name: "Bob"}, {ID: 100, Name: "Alice"}})
+		t.Cleanup(tc.assert)
+	})
+
+	t.Run("too small", func(t *testing.T) {
+		tc := newCase(t, `expected slice and items to contain same number of elements`)
+		s := []*Person{
+			{ID: 101, Name: "Bob"},
+		}
+		SliceContainsAll(tc, s, []*Person{{ID: 101, Name: "Bob"}, {ID: 100, Name: "Alice"}})
+		t.Cleanup(tc.assert)
+	})
+}
+
+func TestSliceContainsSubset(t *testing.T) {
 	tc := newCase(t, `expected slice to contain missing item`)
 	t.Cleanup(tc.assert)
 
@@ -625,7 +657,7 @@ func TestSliceContainsAll(t *testing.T) {
 		{ID: 104, Name: "Dora"},
 	}
 
-	SliceContainsAll(tc, s, []*Person{{ID: 101, Name: "Bob"}, {ID: 105, Name: "Eve"}})
+	SliceContainsSubset(tc, s, []*Person{{ID: 101, Name: "Bob"}, {ID: 105, Name: "Eve"}})
 }
 
 func TestPositive(t *testing.T) {

--- a/test.go
+++ b/test.go
@@ -188,15 +188,26 @@ func SliceContains[A any](t T, slice []A, item A, scripts ...PostScript) {
 	invoke(t, assertions.SliceContains(slice, item), scripts...)
 }
 
+// SliceNotContains asserts item does not exist in slice, using cmp.Equal to
+// compare elements.
 func SliceNotContains[A any](t T, slice []A, item A, scripts ...PostScript) {
 	t.Helper()
 	invoke(t, assertions.SliceNotContains(slice, item), scripts...)
 }
 
-// SliceContainsAll asserts each item in items is contained in slice.
+// SliceContainsAll asserts slice and items contain the same elements, but in
+// no particular order. The number of elements in slice and items must be the
+// same.
 func SliceContainsAll[A any](t T, slice, items []A, scripts ...PostScript) {
 	t.Helper()
 	invoke(t, assertions.SliceContainsAll(slice, items), scripts...)
+}
+
+// SliceContainsSubset asserts slice contains each item in items, in no particular
+// order. There could be additional elements in slice not in items.
+func SliceContainsSubset[A any](t T, slice, items []A, scripts ...PostScript) {
+	t.Helper()
+	invoke(t, assertions.SliceContainsSubset(slice, items), scripts...)
 }
 
 // Positive asserts n > 0.

--- a/test_test.go
+++ b/test_test.go
@@ -613,6 +613,38 @@ func TestSliceNotContains(t *testing.T) {
 }
 
 func TestSliceContainsAll(t *testing.T) {
+	t.Run("wrong element", func(t *testing.T) {
+		tc := newCase(t, `expected slice to contain missing item`)
+		s := []*Person{
+			{ID: 100, Name: "Alice"},
+			{ID: 101, Name: "Bob"},
+		}
+		SliceContainsAll(tc, s, []*Person{{ID: 101, Name: "Bob"}, {ID: 105, Name: "Eve"}})
+		t.Cleanup(tc.assert)
+	})
+
+	t.Run("too large", func(t *testing.T) {
+		tc := newCase(t, `expected slice and items to contain same number of elements`)
+		s := []*Person{
+			{ID: 100, Name: "Alice"},
+			{ID: 101, Name: "Bob"},
+			{ID: 102, Name: "Carl"},
+		}
+		SliceContainsAll(tc, s, []*Person{{ID: 101, Name: "Bob"}, {ID: 100, Name: "Alice"}})
+		t.Cleanup(tc.assert)
+	})
+
+	t.Run("too small", func(t *testing.T) {
+		tc := newCase(t, `expected slice and items to contain same number of elements`)
+		s := []*Person{
+			{ID: 101, Name: "Bob"},
+		}
+		SliceContainsAll(tc, s, []*Person{{ID: 101, Name: "Bob"}, {ID: 100, Name: "Alice"}})
+		t.Cleanup(tc.assert)
+	})
+}
+
+func TestSliceContainsSubset(t *testing.T) {
 	tc := newCase(t, `expected slice to contain missing item`)
 	t.Cleanup(tc.assert)
 
@@ -623,7 +655,7 @@ func TestSliceContainsAll(t *testing.T) {
 		{ID: 104, Name: "Dora"},
 	}
 
-	SliceContainsAll(tc, s, []*Person{{ID: 101, Name: "Bob"}, {ID: 105, Name: "Eve"}})
+	SliceContainsSubset(tc, s, []*Person{{ID: 101, Name: "Bob"}, {ID: 105, Name: "Eve"}})
 }
 
 func TestPositive(t *testing.T) {


### PR DESCRIPTION
This PR fixes SliceContainsAll to match on the number of elements,
and introduce SliceContainsSubset to match only on a subset of elements.
