### PR TITLE
slices: make slice equality comparator flexible on target type

### DIFF
--- a/internal/assertions/assertions.go
+++ b/internal/assertions/assertions.go
@@ -64,7 +64,7 @@ func contains[C comparable](slice []C, item C) bool {
 	return found
 }
 
-func containsFunc[A any](slice []A, item A, eq func(a, b A) bool) bool {
+func containsFunc[A, B any](slice []A, item B, eq func(a A, b B) bool) bool {
 	found := false
 	for i := 0; i < len(slice); i++ {
 		if eq(slice[i], item) {
@@ -354,7 +354,7 @@ func SliceContainsOp[C comparable](slice []C, item C) (s string) {
 	return
 }
 
-func SliceContainsFunc[A any](slice []A, item A, eq func(a, b A) bool) (s string) {
+func SliceContainsFunc[A, B any](slice []A, item B, eq func(a A, b B) bool) (s string) {
 	if !containsFunc(slice, item, eq) {
 		s = "expected slice to contain missing item via 'eq' function\n"
 		s += fmt.Sprintf("↪ slice is missing %#v\n", item)

--- a/must/must.go
+++ b/must/must.go
@@ -181,7 +181,7 @@ func SliceContainsOp[C comparable](t T, slice []C, item C, settings ...Setting) 
 }
 
 // SliceContainsFunc asserts item exists in slice, using eq to compare elements.
-func SliceContainsFunc[A any](t T, slice []A, item A, eq func(a, b A) bool, settings ...Setting) {
+func SliceContainsFunc[A, B any](t T, slice []A, item B, eq func(a A, b B) bool, settings ...Setting) {
 	t.Helper()
 	invoke(t, assertions.SliceContainsFunc(slice, item, eq), settings...)
 }

--- a/must/must_test.go
+++ b/must/must_test.go
@@ -581,8 +581,8 @@ func TestSliceContainsFunc(t *testing.T) {
 		{ID: 101, Name: "Bob"},
 	}
 
-	SliceContainsFunc(tc, s, &Person{ID: 102, Name: "Carl"}, func(a, b *Person) bool {
-		return a.ID == b.ID && a.Name == b.Name
+	SliceContainsFunc(tc, s, "Carl", func(a *Person, name string) bool {
+		return a.Name == name
 	})
 }
 

--- a/test.go
+++ b/test.go
@@ -179,7 +179,7 @@ func SliceContainsOp[C comparable](t T, slice []C, item C, settings ...Setting) 
 }
 
 // SliceContainsFunc asserts item exists in slice, using eq to compare elements.
-func SliceContainsFunc[A any](t T, slice []A, item A, eq func(a, b A) bool, settings ...Setting) {
+func SliceContainsFunc[A, B any](t T, slice []A, item B, eq func(a A, b B) bool, settings ...Setting) {
 	t.Helper()
 	invoke(t, assertions.SliceContainsFunc(slice, item, eq), settings...)
 }

--- a/test_test.go
+++ b/test_test.go
@@ -579,8 +579,8 @@ func TestSliceContainsFunc(t *testing.T) {
 		{ID: 101, Name: "Bob"},
 	}
 
-	SliceContainsFunc(tc, s, &Person{ID: 102, Name: "Carl"}, func(a, b *Person) bool {
-		return a.ID == b.ID && a.Name == b.Name
+	SliceContainsFunc(tc, s, "Carl", func(a *Person, name string) bool {
+		return a.Name == name
 	})
 }
 


### PR DESCRIPTION
This PR enables `SliceContainsFunc` to accept a different type as the
target from the slice elements type. For example if we have a slice
of Person objects but want to detect if the slice contains a person
with a particular name (string), we can now use a comparator of
signature `func(Person, string) bool` - rather than needing a whole
Person struct for the target.

Closes #88 

Worth noting that technically just the predicate function is sufficient, as is done in the `slices` package https://pkg.go.dev/golang.org/x/exp/slices#ContainsFunc - however in the context of test case assertions I think it's more valuable to have the target value explicitly part of the assertion signature. 