### PR TITLE
contains: add ContainsSubset assertion

### DIFF
--- a/internal/assertions/assertions.go
+++ b/internal/assertions/assertions.go
@@ -1178,6 +1178,18 @@ func Contains[C any](i C, c interfaces.ContainsFunc[C]) (s string) {
 	return
 }
 
+func ContainsSubset[C any](elements []C, container interfaces.ContainsFunc[C]) (s string) {
+	for i := 0; i < len(elements); i++ {
+		element := elements[i]
+		if !container.Contains(element) {
+			s = "expected to contain element, but does not\n"
+			s += arrow("element: %v\n", element)
+			return
+		}
+	}
+	return
+}
+
 func NotContains[C any](i C, c interfaces.ContainsFunc[C]) (s string) {
 	if c.Contains(i) {
 		s = "expected not to contain element, but it does\n"
@@ -1193,4 +1205,8 @@ func Wait(wc *wait.Constraint) (s string) {
 		// context info?
 	}
 	return
+}
+
+func arrow(msg string, args ...any) string {
+	return fmt.Sprintf("↪ "+msg, args...)
 }

--- a/must/must.go
+++ b/must/must.go
@@ -685,6 +685,13 @@ func Contains[C any](t T, element C, container interfaces.ContainsFunc[C], setti
 	invoke(t, assertions.Contains(element, container), settings...)
 }
 
+// ContainsSubset asserts each element in elements exists in container, in no particular order.
+// There may be elements in container beyond what is present in elements.
+func ContainsSubset[C any](t T, elements []C, container interfaces.ContainsFunc[C], settings ...Setting) {
+	t.Helper()
+	invoke(t, assertions.ContainsSubset(elements, container), settings...)
+}
+
 // NotContains asserts container.ContainsFunc(element) is false.
 func NotContains[C any](t T, element C, container interfaces.ContainsFunc[C], settings ...Setting) {
 	t.Helper()

--- a/must/must_test.go
+++ b/must/must_test.go
@@ -1487,6 +1487,14 @@ func TestContains(t *testing.T) {
 	Contains[string](tc, "apple", c)
 }
 
+func TestContainsSubset(t *testing.T) {
+	tc := newCase(t, `expected to contain element, but does not`)
+	t.Cleanup(tc.assert)
+
+	c := &container[string]{contains: false}
+	ContainsSubset[string](tc, []string{"a", "b"}, c)
+}
+
 func TestNotContains(t *testing.T) {
 	tc := newCase(t, `expected not to contain element, but it does`)
 	t.Cleanup(tc.assert)

--- a/test.go
+++ b/test.go
@@ -683,6 +683,13 @@ func Contains[C any](t T, element C, container interfaces.ContainsFunc[C], setti
 	invoke(t, assertions.Contains(element, container), settings...)
 }
 
+// ContainsSubset asserts each element in elements exists in container, in no particular order.
+// There may be elements in container beyond what is present in elements.
+func ContainsSubset[C any](t T, elements []C, container interfaces.ContainsFunc[C], settings ...Setting) {
+	t.Helper()
+	invoke(t, assertions.ContainsSubset(elements, container), settings...)
+}
+
 // NotContains asserts container.ContainsFunc(element) is false.
 func NotContains[C any](t T, element C, container interfaces.ContainsFunc[C], settings ...Setting) {
 	t.Helper()

--- a/test_test.go
+++ b/test_test.go
@@ -1485,6 +1485,14 @@ func TestContains(t *testing.T) {
 	Contains[string](tc, "apple", c)
 }
 
+func TestContainsSubset(t *testing.T) {
+	tc := newCase(t, `expected to contain element, but does not`)
+	t.Cleanup(tc.assert)
+
+	c := &container[string]{contains: false}
+	ContainsSubset[string](tc, []string{"a", "b"}, c)
+}
+
 func TestNotContains(t *testing.T) {
 	tc := newCase(t, `expected not to contain element, but it does`)
 	t.Cleanup(tc.assert)


### PR DESCRIPTION
This PR adds a ContainsSubset assertion for asserting a Container
contains each element in a slice of elements.

Closes #97 

Note that `ContainsAll` is not technically possible for the `Container` interface which only mandates a `Contains` method - no way to know if it contains _additional_ elements.