### PR TITLE
test: add ValidJSON and ValidJSONBytes assertions

### DIFF
--- a/internal/assertions/assertions.go
+++ b/internal/assertions/assertions.go
@@ -249,6 +249,21 @@ func EqJSON(exp, val string) (s string) {
 	return
 }
 
+func ValidJSON(input string) (s string) {
+	return validJSON([]byte(input))
+}
+
+func ValidJSONBytes(input []byte) (s string) {
+	return validJSON(input)
+}
+
+func validJSON(input []byte) (s string) {
+	if !json.Valid([]byte(input)) {
+		return "expected input to be valid json\n"
+	}
+	return
+}
+
 func EqSliceFunc[A any](exp, val []A, eq func(a, b A) bool) (s string) {
 	lenA, lenB := len(exp), len(val)
 

--- a/must/must.go
+++ b/must/must.go
@@ -117,6 +117,18 @@ func EqJSON(t T, exp, val string, settings ...Setting) {
 	invoke(t, assertions.EqJSON(exp, val), settings...)
 }
 
+// ValidJSON asserts js is valid JSON.
+func ValidJSON(t T, js string, settings ...Setting) {
+	t.Helper()
+	invoke(t, assertions.ValidJSON(js), settings...)
+}
+
+// ValidJSONBytes asserts js is valid JSON.
+func ValidJSONBytes(t T, js []byte, settings ...Setting) {
+	t.Helper()
+	invoke(t, assertions.ValidJSONBytes(js))
+}
+
 // Equal asserts val.Equal(exp).
 func Equal[E interfaces.EqualFunc[E]](t T, exp, val E, settings ...Setting) {
 	t.Helper()

--- a/must/must_test.go
+++ b/must/must_test.go
@@ -346,6 +346,20 @@ func TestEqJSON_PS(t *testing.T) {
 	EqJSON(tc, `"one"`, `"two"`, tc.TestPostScript("eq json"))
 }
 
+func TestValidJSON(t *testing.T) {
+	tc := newCapture(t)
+	t.Cleanup(tc.assert)
+
+	ValidJSON(tc, `{"a":1, "b":}`)
+}
+
+func TestValidJSONBytes(t *testing.T) {
+	tc := newCapture(t)
+	t.Cleanup(tc.assert)
+
+	ValidJSONBytes(tc, []byte(`{"a":1, "b":}`))
+}
+
 func TestSliceEqFunc(t *testing.T) {
 	t.Run("length", func(t *testing.T) {
 		tc := newCase(t, `expected slices of same length`)

--- a/test.go
+++ b/test.go
@@ -115,6 +115,18 @@ func EqJSON(t T, exp, val string, settings ...Setting) {
 	invoke(t, assertions.EqJSON(exp, val), settings...)
 }
 
+// ValidJSON asserts js is valid JSON.
+func ValidJSON(t T, js string, settings ...Setting) {
+	t.Helper()
+	invoke(t, assertions.ValidJSON(js), settings...)
+}
+
+// ValidJSONBytes asserts js is valid JSON.
+func ValidJSONBytes(t T, js []byte, settings ...Setting) {
+	t.Helper()
+	invoke(t, assertions.ValidJSONBytes(js))
+}
+
 // Equal asserts val.Equal(exp).
 func Equal[E interfaces.EqualFunc[E]](t T, exp, val E, settings ...Setting) {
 	t.Helper()

--- a/test_test.go
+++ b/test_test.go
@@ -344,6 +344,20 @@ func TestEqJSON_PS(t *testing.T) {
 	EqJSON(tc, `"one"`, `"two"`, tc.TestPostScript("eq json"))
 }
 
+func TestValidJSON(t *testing.T) {
+	tc := newCapture(t)
+	t.Cleanup(tc.assert)
+
+	ValidJSON(tc, `{"a":1, "b":}`)
+}
+
+func TestValidJSONBytes(t *testing.T) {
+	tc := newCapture(t)
+	t.Cleanup(tc.assert)
+
+	ValidJSONBytes(tc, []byte(`{"a":1, "b":}`))
+}
+
 func TestSliceEqFunc(t *testing.T) {
 	t.Run("length", func(t *testing.T) {
 		tc := newCase(t, `expected slices of same length`)


### PR DESCRIPTION
Add heper methods that defer to Go json.Valid function for checking
a string or byte slice is valid json.

Closes #103
