### PR TITLE
slices: make EqSliceFunc more flexible on types

### DIFF
--- a/internal/assertions/assertions.go
+++ b/internal/assertions/assertions.go
@@ -264,7 +264,7 @@ func validJSON(input []byte) (s string) {
 	return
 }
 
-func EqSliceFunc[A any](exp, val []A, eq func(a, b A) bool) (s string) {
+func EqSliceFunc[A, B any](exp []B, val []A, eq func(a A, b B) bool) (s string) {
 	lenA, lenB := len(exp), len(val)
 
 	if lenA != lenB {
@@ -277,7 +277,7 @@ func EqSliceFunc[A any](exp, val []A, eq func(a, b A) bool) (s string) {
 
 	miss := false
 	for i := 0; i < lenA; i++ {
-		if !eq(exp[i], val[i]) {
+		if !eq(val[i], exp[i]) {
 			miss = true
 			break
 		}

--- a/must/must.go
+++ b/must/must.go
@@ -147,8 +147,8 @@ func Lesser[L interfaces.LessFunc[L]](t T, exp, val L, settings ...Setting) {
 	invoke(t, assertions.Lesser(exp, val), settings...)
 }
 
-// SliceEqFunc asserts elements of exp and val are the same using eq.
-func SliceEqFunc[A any](t T, exp, val []A, eq func(a, b A) bool, settings ...Setting) {
+// SliceEqFunc asserts elements of val satisfy eq for the corresponding element in exp.
+func SliceEqFunc[A, B any](t T, exp []B, val []A, eq func(expectation A, value B) bool, settings ...Setting) {
 	t.Helper()
 	invoke(t, assertions.EqSliceFunc(exp, val, eq), settings...)
 }

--- a/must/must_test.go
+++ b/must/must_test.go
@@ -391,6 +391,20 @@ func TestSliceEqFunc(t *testing.T) {
 			return a.ID == b.ID
 		})
 	})
+
+	t.Run("translate", func(t *testing.T) {
+		tc := newCase(t, `expected slice equality via 'eq' function`)
+		t.Cleanup(tc.assert)
+
+		values := []*Person{
+			{ID: 100, Name: "Alice"},
+			{ID: 101, Name: "Bob"},
+		}
+		exp := []string{"Alice", "Carl"}
+		SliceEqFunc(tc, exp, values, func(a *Person, name string) bool {
+			return a.Name == name
+		})
+	})
 }
 
 func TestSliceEqFunc_PS(t *testing.T) {

--- a/test.go
+++ b/test.go
@@ -145,8 +145,8 @@ func Lesser[L interfaces.LessFunc[L]](t T, exp, val L, settings ...Setting) {
 	invoke(t, assertions.Lesser(exp, val), settings...)
 }
 
-// SliceEqFunc asserts elements of exp and val are the same using eq.
-func SliceEqFunc[A any](t T, exp, val []A, eq func(a, b A) bool, settings ...Setting) {
+// SliceEqFunc asserts elements of val satisfy eq for the corresponding element in exp.
+func SliceEqFunc[A, B any](t T, exp []B, val []A, eq func(expectation A, value B) bool, settings ...Setting) {
 	t.Helper()
 	invoke(t, assertions.EqSliceFunc(exp, val, eq), settings...)
 }

--- a/test_test.go
+++ b/test_test.go
@@ -389,6 +389,20 @@ func TestSliceEqFunc(t *testing.T) {
 			return a.ID == b.ID
 		})
 	})
+
+	t.Run("translate", func(t *testing.T) {
+		tc := newCase(t, `expected slice equality via 'eq' function`)
+		t.Cleanup(tc.assert)
+
+		values := []*Person{
+			{ID: 100, Name: "Alice"},
+			{ID: 101, Name: "Bob"},
+		}
+		exp := []string{"Alice", "Carl"}
+		SliceEqFunc(tc, exp, values, func(a *Person, name string) bool {
+			return a.Name == name
+		})
+	})
 }
 
 func TestSliceEqFunc_PS(t *testing.T) {


### PR DESCRIPTION
This PR makes `EqSliceFunc` accept slices of two different types that
are then compared by the supplied comparator - which accepts one of
each type.

Fixes https://github.com/shoenig/test/issues/107

motivating example use

```go
must.SliceEqFunc(t, []string{
  "add",    // PreRun
  "update", // Update
  "remove", // PostRun
  "add",    // PreRun (replacement)
}, ops, func(val regMock.Operation, exp string) bool {
  return val.Op == exp
})
```