### PR TITLE
tests: add StructEqual() for verifying Equal method of structs

### DIFF
--- a/interfaces/interfaces.go
+++ b/interfaces/interfaces.go
@@ -11,6 +11,20 @@ type EqualFunc[A any] interface {
 	Equal(A) bool
 }
 
+// CopyFunc represents a type implementing the Copy method.
+type CopyFunc[A any] interface {
+	Copy() A
+}
+
+// CopyEqual represents a type satisfying both EqualFunc and CopyFunc.
+type CopyEqual[T any] interface {
+	EqualFunc[T]
+	CopyFunc[T]
+}
+
+// TweakFunc is used for modifying a value in tests.
+type TweakFunc[E CopyEqual[E]] func(E)
+
 // LessFunc represents any type implementing the Less method.
 type LessFunc[A any] interface {
 	Less(A) bool

--- a/internal/util/slices.go
+++ b/internal/util/slices.go
@@ -1,0 +1,10 @@
+package util
+
+// CloneSliceFunc creates a copy of A by first applying convert to each element.
+func CloneSliceFunc[A, B any](original []A, convert func(item A) B) []B {
+	clone := make([]B, len(original))
+	for i := 0; i < len(original); i++ {
+		clone[i] = convert(original[i])
+	}
+	return clone
+}

--- a/internal/util/slices_test.go
+++ b/internal/util/slices_test.go
@@ -1,0 +1,36 @@
+package util
+
+import (
+	"strconv"
+	"testing"
+)
+
+func TestCloneSliceFunc(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		result := CloneSliceFunc([]int{}, func(i int) string {
+			return strconv.Itoa(i)
+		})
+		if len(result) > 0 {
+			t.Fatal("expected empty slice")
+		}
+	})
+
+	t.Run("non empty", func(t *testing.T) {
+		original := []int{1, 4, 5}
+		result := CloneSliceFunc(original, func(i int) string {
+			return strconv.Itoa(i)
+		})
+		if len(result) != 3 {
+			t.Fatal("expected length of 3")
+		}
+		if result[0] != "1" {
+			t.Fatal("expected result[0] == 1")
+		}
+		if result[1] != "4" {
+			t.Fatal("expected result[1] == 4")
+		}
+		if result[2] != "5" {
+			t.Fatal("expected result[2] == 5")
+		}
+	})
+}

--- a/must/must_test.go
+++ b/must/must_test.go
@@ -1477,6 +1477,32 @@ func (c *container[T]) Len() int {
 	return c.length
 }
 
+func (c *container[T]) Copy() *container[T] {
+	return &container[T]{
+		contains: c.contains,
+		empty:    c.empty,
+		size:     c.size,
+		length:   c.length,
+	}
+}
+
+func (c *container[T]) Equal(o *container[T]) bool {
+	if c == nil || o == nil {
+		return c == o
+	}
+	switch {
+	case c.contains != o.contains:
+		return false
+	case c.empty != o.empty:
+		return false
+	case c.size != o.size:
+		return false
+	case c.length != o.length:
+		return false
+	}
+	return true
+}
+
 func TestEmpty(t *testing.T) {
 	tc := newCase(t, `expected to be empty, but was not`)
 	t.Cleanup(tc.assert)
@@ -1561,4 +1587,28 @@ func TestWait_TestFunc(t *testing.T) {
 		wait.TestFunc(func() (bool, error) { return false, errors.New("fail") }),
 		wait.Timeout(100*time.Millisecond),
 	))
+}
+
+func TestStructEqual(t *testing.T) {
+	tc := newCase(t, `expected inequality via .Equal method`)
+	t.Cleanup(tc.assert)
+
+	StructEqual[*container[int]](tc, &container[int]{
+		contains: true,
+		empty:    true,
+		size:     1,
+		length:   2,
+	}, []Tweak[*container[int]]{{
+		Field: "contains",
+		Apply: func(c *container[int]) { c.contains = false },
+	}, {
+		Field: "empty",
+		Apply: func(c *container[int]) { c.empty = false },
+	}, {
+		Field: "size",
+		Apply: func(c *container[int]) { c.size = 9 },
+	}, {
+		Field: "length",
+		Apply: func(c *container[int]) { c.length = 2 }, // no mod
+	}})
 }

--- a/test.go
+++ b/test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/shoenig/test/internal/assertions"
 	"github.com/shoenig/test/internal/brokenfs"
 	"github.com/shoenig/test/internal/constraints"
+	"github.com/shoenig/test/internal/util"
 	"github.com/shoenig/test/wait"
 )
 
@@ -712,4 +713,28 @@ func NotContains[C any](t T, element C, container interfaces.ContainsFunc[C], se
 func Wait(t T, wc *wait.Constraint, settings ...Setting) {
 	t.Helper()
 	invoke(t, assertions.Wait(wc), settings...)
+}
+
+// Tweak is used to modify a struct and assert its Equal method captures the
+// modification.
+//
+// Field is the name of the struct field and is used only for error printing.
+// Apply is a function that modifies E.
+type Tweak[E interfaces.CopyEqual[E]] struct {
+	Field string
+	Apply interfaces.TweakFunc[E]
+}
+
+// StructEqual will apply each Tweak and assert E.Equal captures the modification.
+func StructEqual[E interfaces.CopyEqual[E]](t T, original E, tweaks []Tweak[E], settings ...Setting) {
+	t.Helper()
+	invoke(t, assertions.StructEqual(
+		original,
+		util.CloneSliceFunc[Tweak[E], assertions.Tweak[E]](
+			tweaks,
+			func(tweak Tweak[E]) assertions.Tweak[E] {
+				return assertions.Tweak[E]{Field: tweak.Field, Apply: tweak.Apply}
+			},
+		),
+	), settings...)
 }

--- a/test_test.go
+++ b/test_test.go
@@ -1475,6 +1475,32 @@ func (c *container[T]) Len() int {
 	return c.length
 }
 
+func (c *container[T]) Copy() *container[T] {
+	return &container[T]{
+		contains: c.contains,
+		empty:    c.empty,
+		size:     c.size,
+		length:   c.length,
+	}
+}
+
+func (c *container[T]) Equal(o *container[T]) bool {
+	if c == nil || o == nil {
+		return c == o
+	}
+	switch {
+	case c.contains != o.contains:
+		return false
+	case c.empty != o.empty:
+		return false
+	case c.size != o.size:
+		return false
+	case c.length != o.length:
+		return false
+	}
+	return true
+}
+
 func TestEmpty(t *testing.T) {
 	tc := newCase(t, `expected to be empty, but was not`)
 	t.Cleanup(tc.assert)
@@ -1559,4 +1585,28 @@ func TestWait_TestFunc(t *testing.T) {
 		wait.TestFunc(func() (bool, error) { return false, errors.New("fail") }),
 		wait.Timeout(100*time.Millisecond),
 	))
+}
+
+func TestStructEqual(t *testing.T) {
+	tc := newCase(t, `expected inequality via .Equal method`)
+	t.Cleanup(tc.assert)
+
+	StructEqual[*container[int]](tc, &container[int]{
+		contains: true,
+		empty:    true,
+		size:     1,
+		length:   2,
+	}, []Tweak[*container[int]]{{
+		Field: "contains",
+		Apply: func(c *container[int]) { c.contains = false },
+	}, {
+		Field: "empty",
+		Apply: func(c *container[int]) { c.empty = false },
+	}, {
+		Field: "size",
+		Apply: func(c *container[int]) { c.size = 9 },
+	}, {
+		Field: "length",
+		Apply: func(c *container[int]) { c.length = 2 }, // no mod
+	}})
 }


### PR DESCRIPTION
This PR adds StructEqual which is helpful for verifying that modifying
the fields of a struct will cause the Equal method of the struct to
no longer return true.

e.g. usage

```go
func TestAffinity_Equal(t *testing.T) {
	must.Equal[*Affinity](t, nil, nil)
	must.NotEqual[*Affinity](t, nil, new(Affinity))
	must.StructEqual(t, &Affinity{
		LTarget: "left",
		RTarget: "right",
		Operand: "op",
		Weight:  100,
	}, []must.Tweak[*Affinity]{{
		Field: "LTarget",
		Apply: func(a *Affinity) { a.LTarget = "left2" },
	}, {
		Field: "RTarget",
		Apply: func(a *Affinity) { a.RTarget = "right2" },
	}, {
		Field: "Operand",
		Apply: func(a *Affinity) { a.Operand = "op2" },
	}, {
		Field: "Weight",
		Apply: func(a *Affinity) { a.Weight = 50 },
	}})
}
```