### PR TITLE
test: add Tweaks convenience type for a []Tweak

### DIFF
--- a/must/must.go
+++ b/must/must.go
@@ -727,8 +727,11 @@ type Tweak[E interfaces.CopyEqual[E]] struct {
 	Apply interfaces.TweakFunc[E]
 }
 
+// Tweaks is a slice of Tweak.
+type Tweaks[E interfaces.CopyEqual[E]] []Tweak[E]
+
 // StructEqual will apply each Tweak and assert E.Equal captures the modification.
-func StructEqual[E interfaces.CopyEqual[E]](t T, original E, tweaks []Tweak[E], settings ...Setting) {
+func StructEqual[E interfaces.CopyEqual[E]](t T, original E, tweaks Tweaks[E], settings ...Setting) {
 	t.Helper()
 	invoke(t, assertions.StructEqual(
 		original,

--- a/must/must_test.go
+++ b/must/must_test.go
@@ -1607,12 +1607,36 @@ func TestStructEqual(t *testing.T) {
 	tc := newCase(t, `expected inequality via .Equal method`)
 	t.Cleanup(tc.assert)
 
-	StructEqual[*container[int]](tc, &container[int]{
+	StructEqual(tc, &container[int]{
 		contains: true,
 		empty:    true,
 		size:     1,
 		length:   2,
 	}, []Tweak[*container[int]]{{
+		Field: "contains",
+		Apply: func(c *container[int]) { c.contains = false },
+	}, {
+		Field: "empty",
+		Apply: func(c *container[int]) { c.empty = false },
+	}, {
+		Field: "size",
+		Apply: func(c *container[int]) { c.size = 9 },
+	}, {
+		Field: "length",
+		Apply: func(c *container[int]) { c.length = 2 }, // no mod
+	}})
+}
+
+func TestStructEqual_Tweaks(t *testing.T) {
+	tc := newCase(t, `expected inequality via .Equal method`)
+	t.Cleanup(tc.assert)
+
+	StructEqual(tc, &container[int]{
+		contains: true,
+		empty:    true,
+		size:     1,
+		length:   2,
+	}, Tweaks[*container[int]]{{
 		Field: "contains",
 		Apply: func(c *container[int]) { c.contains = false },
 	}, {

--- a/test.go
+++ b/test.go
@@ -725,8 +725,11 @@ type Tweak[E interfaces.CopyEqual[E]] struct {
 	Apply interfaces.TweakFunc[E]
 }
 
+// Tweaks is a slice of Tweak.
+type Tweaks[E interfaces.CopyEqual[E]] []Tweak[E]
+
 // StructEqual will apply each Tweak and assert E.Equal captures the modification.
-func StructEqual[E interfaces.CopyEqual[E]](t T, original E, tweaks []Tweak[E], settings ...Setting) {
+func StructEqual[E interfaces.CopyEqual[E]](t T, original E, tweaks Tweaks[E], settings ...Setting) {
 	t.Helper()
 	invoke(t, assertions.StructEqual(
 		original,

--- a/test_test.go
+++ b/test_test.go
@@ -1605,12 +1605,36 @@ func TestStructEqual(t *testing.T) {
 	tc := newCase(t, `expected inequality via .Equal method`)
 	t.Cleanup(tc.assert)
 
-	StructEqual[*container[int]](tc, &container[int]{
+	StructEqual(tc, &container[int]{
 		contains: true,
 		empty:    true,
 		size:     1,
 		length:   2,
 	}, []Tweak[*container[int]]{{
+		Field: "contains",
+		Apply: func(c *container[int]) { c.contains = false },
+	}, {
+		Field: "empty",
+		Apply: func(c *container[int]) { c.empty = false },
+	}, {
+		Field: "size",
+		Apply: func(c *container[int]) { c.size = 9 },
+	}, {
+		Field: "length",
+		Apply: func(c *container[int]) { c.length = 2 }, // no mod
+	}})
+}
+
+func TestStructEqual_Tweaks(t *testing.T) {
+	tc := newCase(t, `expected inequality via .Equal method`)
+	t.Cleanup(tc.assert)
+
+	StructEqual(tc, &container[int]{
+		contains: true,
+		empty:    true,
+		size:     1,
+		length:   2,
+	}, Tweaks[*container[int]]{{
 		Field: "contains",
 		Apply: func(c *container[int]) { c.contains = false },
 	}, {


### PR DESCRIPTION
When writing SliceEqual tests you have to provide a []Tweak, may as well
make it a Tweaks type so you don't have to have the slice brackets.
