### PR TITLE
test: add `DirMode`, and `DireModeFS`

### DIFF
--- a/internal/assertions/assertions.go
+++ b/internal/assertions/assertions.go
@@ -1054,6 +1054,29 @@ func FileModeFS(system fs.FS, path string, permissions fs.FileMode) (s string) {
 	return
 }
 
+func DirModeFS(system fs.FS, path string, permissions fs.FileMode) (s string) {
+	info, err := fs.Stat(system, path)
+	if err != nil {
+		s = "expected to stat path\n"
+		s += bullet(" name: %s\n", path)
+		s += bullet("error: %s\n", err)
+		return
+	}
+	if !info.IsDir() {
+		s = "expected to stat a directory\n"
+		s += bullet("name: %s\n", path)
+		return
+	}
+	mode := info.Mode()
+	if permissions != mode {
+		s = "expected different file permissions\n"
+		s += bullet("name: %s\n", path)
+		s += bullet(" exp: %s\n", permissions)
+		s += bullet(" got: %s\n", mode)
+	}
+	return
+}
+
 func FileContainsFS(system fs.FS, file, content string) (s string) {
 	b, err := fs.ReadFile(system, file)
 	if err != nil {

--- a/must/must.go
+++ b/must/must.go
@@ -617,6 +617,22 @@ func FileMode(t T, path string, permissions fs.FileMode, settings ...Setting) {
 	invoke(t, assertions.FileModeFS(os.DirFS(brokenfs.Root), path, permissions), settings...)
 }
 
+// DirModeFS asserts the directory at path on fs.FS has exactly the given permission bits.
+//
+// Example,
+// DirModeFS(t, os.DirFS("/"), "bin", 0655)
+func DirModeFS(t T, system fs.FS, path string, permissions fs.FileMode, settings ...Setting) {
+	t.Helper()
+	invoke(t, assertions.DirModeFS(system, path, permissions), settings...)
+}
+
+// DirMode asserts the directory at path on the OS filesystem has exactly the given permission bits.
+func DirMode(t T, path string, permissions fs.FileMode, settings ...Setting) {
+	t.Helper()
+	path = strings.TrimPrefix(path, "/")
+	invoke(t, assertions.DirModeFS(os.DirFS(brokenfs.Root), path, permissions), settings...)
+}
+
 // FileContainsFS asserts the file on fs.FS contains content as a substring.
 //
 // Often os.DirFS is used to interact with the host filesystem.

--- a/must/must_test.go
+++ b/must/must_test.go
@@ -1439,6 +1439,44 @@ func TestFileMode(t *testing.T) {
 	FileMode(tc, "/bin/find", unexpected)
 }
 
+func TestDirModeFS(t *testing.T) {
+	needsOS(t, "linux")
+
+	t.Run("different permissions", func(t *testing.T) {
+		tc := newCase(t, `expected different file permissions`)
+		t.Cleanup(tc.assert)
+
+		var unexpected os.FileMode = 0755 // (actual 0755)
+		DirModeFS(tc, os.DirFS("/"), "bin", unexpected)
+	})
+
+	t.Run("not a dir", func(t *testing.T) {
+		tc := newCase(t, `expected to stat a directory`)
+		t.Cleanup(tc.assert)
+
+		DirModeFS(tc, os.DirFS("/bin"), "find", os.FileMode(0))
+	})
+}
+
+func TestDirMode(t *testing.T) {
+	needsOS(t, "linux")
+
+	t.Run("different permissions", func(t *testing.T) {
+		tc := newCase(t, `expected different file permissions`)
+		t.Cleanup(tc.assert)
+
+		var unexpected os.FileMode = 0755 // (actual 0755)
+		DirMode(tc, "/bin", unexpected)
+	})
+
+	t.Run("not a dir", func(t *testing.T) {
+		tc := newCase(t, `expected to stat a directory`)
+		t.Cleanup(tc.assert)
+
+		DirMode(tc, "/bin/find", os.FileMode(0))
+	})
+}
+
 func TestFileContainsFS(t *testing.T) {
 	needsOS(t, "linux")
 

--- a/test.go
+++ b/test.go
@@ -615,6 +615,22 @@ func FileMode(t T, path string, permissions fs.FileMode, settings ...Setting) {
 	invoke(t, assertions.FileModeFS(os.DirFS(brokenfs.Root), path, permissions), settings...)
 }
 
+// DirModeFS asserts the directory at path on fs.FS has exactly the given permission bits.
+//
+// Example,
+// DirModeFS(t, os.DirFS("/"), "bin", 0655)
+func DirModeFS(t T, system fs.FS, path string, permissions fs.FileMode, settings ...Setting) {
+	t.Helper()
+	invoke(t, assertions.DirModeFS(system, path, permissions), settings...)
+}
+
+// DirMode asserts the directory at path on the OS filesystem has exactly the given permission bits.
+func DirMode(t T, path string, permissions fs.FileMode, settings ...Setting) {
+	t.Helper()
+	path = strings.TrimPrefix(path, "/")
+	invoke(t, assertions.DirModeFS(os.DirFS(brokenfs.Root), path, permissions), settings...)
+}
+
 // FileContainsFS asserts the file on fs.FS contains content as a substring.
 //
 // Often os.DirFS is used to interact with the host filesystem.

--- a/test_test.go
+++ b/test_test.go
@@ -1437,6 +1437,44 @@ func TestFileMode(t *testing.T) {
 	FileMode(tc, "/bin/find", unexpected)
 }
 
+func TestDirModeFS(t *testing.T) {
+	needsOS(t, "linux")
+
+	t.Run("different permissions", func(t *testing.T) {
+		tc := newCase(t, `expected different file permissions`)
+		t.Cleanup(tc.assert)
+
+		var unexpected os.FileMode = 0755 // (actual 0755)
+		DirModeFS(tc, os.DirFS("/"), "bin", unexpected)
+	})
+
+	t.Run("not a dir", func(t *testing.T) {
+		tc := newCase(t, `expected to stat a directory`)
+		t.Cleanup(tc.assert)
+
+		DirModeFS(tc, os.DirFS("/bin"), "find", os.FileMode(0))
+	})
+}
+
+func TestDirMode(t *testing.T) {
+	needsOS(t, "linux")
+
+	t.Run("different permissions", func(t *testing.T) {
+		tc := newCase(t, `expected different file permissions`)
+		t.Cleanup(tc.assert)
+
+		var unexpected os.FileMode = 0755 // (actual 0755)
+		DirMode(tc, "/bin", unexpected)
+	})
+
+	t.Run("not a dir", func(t *testing.T) {
+		tc := newCase(t, `expected to stat a directory`)
+		t.Cleanup(tc.assert)
+
+		DirMode(tc, "/bin/find", os.FileMode(0))
+	})
+}
+
 func TestFileContainsFS(t *testing.T) {
 	needsOS(t, "linux")
 


### PR DESCRIPTION
#152 
Before `DirMode` func, users had to specify the dir bit using:
```go
FileMode(tc, "/bin", os.ModeDir | 0655)
```
With `DirMode` func, users can omit the `os.ModeDir`
```go
DirMode(tc, "/bin", os.FileMode(0755))
```

Happy easter :smile: :rabbit: 