### PR TITLE
Adding ErrorAssertionFunc function type

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ There are five key packages,
 
 ### Changes
 
+- v1.8.1 adds the function type `ErrorAssertionFunc` that is useful for passing `Error` or `NoError` in table driven tests
+
 :ballot_box_with_check: v1.8.0 introduces the `skip` package for skipping tests!
 
  - New helper functions for skipping out tests based on some given criteria

--- a/must/must.go
+++ b/must/must.go
@@ -21,6 +21,9 @@ import (
 	"github.com/shoenig/test/wait"
 )
 
+// ErrorAssertionFunc allows to pass Error and NoError in table driven tests
+type ErrorAssertionFunc func(t T, err error, settings ...Setting)
+
 // Nil asserts a is nil.
 func Nil(t T, a any, settings ...Setting) {
 	t.Helper()

--- a/test.go
+++ b/test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/shoenig/test/wait"
 )
 
+// ErrorAssertionFunc allows to pass Error and NoError in table driven tests
 type ErrorAssertionFunc func(t T, err error, settings ...Setting)
 
 // Nil asserts a is nil.

--- a/test.go
+++ b/test.go
@@ -19,6 +19,8 @@ import (
 	"github.com/shoenig/test/wait"
 )
 
+type ErrorAssertionFunc func(t T, err error, settings ...Setting)
+
 // Nil asserts a is nil.
 func Nil(t T, a any, settings ...Setting) {
 	t.Helper()


### PR DESCRIPTION
Hi @shoenig, thank you for creating this formidable assertion lib! :)

The type I added is analog to `testify`'s `ErrorAssertionFunc` type that makes it convenient to pass `Error` or `NoError` assertion functions in table driven tests.
Do you like the idea of adding this type?
I wasn't sure what the best placement of the type in the source file would be, so please let me know if you wanna move it somewhere else.
Best,
Cornelius