### PR TITLE
make: rewrite generate.sh so it works on BSD machines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,13 +11,13 @@
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
-# Dependency directories (remove the comment below to include it)
-# vendor/
+# Temporary files
+*.bak
 
 # Go work files
 go.work
 go.work.sum
 
-# macOS
+# macOS files
 .DS_Store
 

--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -2,31 +2,27 @@
 
 set -euo pipefail
 
-cp invocations.go must/invocations.go
-cp invocations_test.go must/invocations_test.go
-cp settings.go must/settings.go
-cp settings_test.go must/settings_test.go
-cp scripts.go must/scripts.go
-cp scripts_test.go must/scripts_test.go
-cp test.go must/must.go
-cp test_test.go must/must_test.go
-cp examples_test.go must/examples_test.go
-sed -i "s|package test|package must|g" must/invocations.go
-sed -i "s|package test|package must|g" must/invocations_test.go
-sed -i "s|package test|package must|g" must/settings.go
-sed -i "s|package test|package must|g" must/settings_test.go
-sed -i "s|package test|package must|g" must/scripts.go
-sed -i "s|package test|package must|g" must/scripts_test.go
-sed -i "s|package test|package must|g" must/must.go
-sed -i "s|package test|package must|g" must/must_test.go
-sed -i "s|package test|package must|g" must/examples_test.go
-sed -i -e "1s|^|// Code generated via scripts/generate.sh. DO NOT EDIT.\n\n|g" must/invocations.go
-sed -i -e "1s|^|// Code generated via scripts/generate.sh. DO NOT EDIT.\n\n|g" must/invocations_test.go
-sed -i -e "1s|^|// Code generated via scripts/generate.sh. DO NOT EDIT.\n\n|g" must/settings.go
-sed -i -e "1s|^|// Code generated via scripts/generate.sh. DO NOT EDIT.\n\n|g" must/settings_test.go
-sed -i -e "1s|^|// Code generated via scripts/generate.sh. DO NOT EDIT.\n\n|g" must/scripts.go
-sed -i -e "1s|^|// Code generated via scripts/generate.sh. DO NOT EDIT.\n\n|g" must/scripts_test.go
-sed -i -e "1s|^|// Code generated via scripts/generate.sh. DO NOT EDIT.\n\n|g" must/must.go
-sed -i -e "1s|^|// Code generated via scripts/generate.sh. DO NOT EDIT.\n\n|g" must/must_test.go
-sed -i -e "1s|^|// Code generated via scripts/generate.sh. DO NOT EDIT.\n\n|g" must/examples_test.go
+apply() {
+  original="${1}"
+  clone="must/${original}"
+  cp "${original}" "${clone}"
+  sed -i.bak "s|package test|package must|g" "${clone}"
+  sed -i.bak -e "1s|^|// Code generated via scripts/generate.sh. DO NOT EDIT.\n\n|g" "${clone}"
+}
 
+apply invocations.go
+apply invocations_test.go
+apply settings.go
+apply settings_test.go
+apply scripts.go
+apply scripts_test.go
+apply test.go
+apply test_test.go
+apply examples_test.go
+
+# rename core test files
+mv must/test.go must/must.go
+mv must/test_test.go must/must_test.go
+
+# cleanup *.bak files
+find . -name *.bak | xargs rm


### PR DESCRIPTION
Use the .bak trick suggested in https://stackoverflow.com/a/22084103

Also cleanup the script by applying a function to each file to be generated rather than doing each operation individually for each file.

Fixes #156 