### PR TITLE
mark more internal funcs as helpers

### DIFF
--- a/assert.go
+++ b/assert.go
@@ -11,5 +11,6 @@ type T interface {
 }
 
 func errorf(t T, msg string, args ...any) {
+	t.Helper()
 	t.Errorf(msg, args...)
 }

--- a/invocations.go
+++ b/invocations.go
@@ -15,12 +15,14 @@ func passing(result string) bool {
 }
 
 func fail(t T, msg string, scripts ...PostScript) {
+	t.Helper()
 	c := assertions.Caller()
 	s := c + msg + "\n" + run(scripts...)
 	errorf(t, "\n"+strings.TrimSpace(s)+"\n")
 }
 
 func invoke(t T, result string, settings ...Setting) {
+	t.Helper()
 	result = strings.TrimSpace(result)
 	if !passing(result) {
 		fail(t, result, scripts(settings...)...)

--- a/must/assert.go
+++ b/must/assert.go
@@ -11,5 +11,6 @@ type T interface {
 }
 
 func errorf(t T, msg string, args ...any) {
+	t.Helper()
 	t.Fatalf(msg, args...)
 }

--- a/must/invocations.go
+++ b/must/invocations.go
@@ -17,12 +17,14 @@ func passing(result string) bool {
 }
 
 func fail(t T, msg string, scripts ...PostScript) {
+	t.Helper()
 	c := assertions.Caller()
 	s := c + msg + "\n" + run(scripts...)
 	errorf(t, "\n"+strings.TrimSpace(s)+"\n")
 }
 
 func invoke(t T, result string, settings ...Setting) {
+	t.Helper()
 	result = strings.TrimSpace(result)
 	if !passing(result) {
 		fail(t, result, scripts(settings...)...)


### PR DESCRIPTION
hi!

given this `test_test.go`:

```go
   1 package main
   2
   3 import (
   4     "testing"
   5
   6     "github.com/shoenig/test"
   7     "github.com/shoenig/test/must"
   8 )
   9
  10 func TestHelperStack(t *testing.T) {
  11     failSadly(t)
  12 }
  13
  14 func failSadly(t *testing.T) {
  15     t.Helper()
  16     test.NotNil(t, nil)
  17     must.NotNil(t, nil)
  18 }
```

before this change, error stack shows `assert.go` from this lib:

```
$ go test .
--- FAIL: TestHelperStack (0.00s)
    assert.go:14:
        test_test.go:16: expected to not be nil; is nil
    assert.go:14:
        test_test.go:17: expected to not be nil; is nil
```

after, shows my test file(s) with the context relevant to me and my terrible mistakes:

```
$ go test .
--- FAIL: TestHelperStack (0.00s)
    test_test.go:11:
        test_test.go:16: expected to not be nil; is nil
    test_test.go:11:
        test_test.go:17: expected to not be nil; is nil

```