### PR TITLE
Fix broken file and dir helpers on Windows

### DIFF
--- a/internal/assertions/assertions.go
+++ b/internal/assertions/assertions.go
@@ -975,6 +975,29 @@ func MapNotContainsValueEqual[M ~map[K]V, K comparable, V interfaces.EqualFunc[V
 	})
 }
 
+func FileExists(file string) (s string) {
+	info, err := os.Stat(file)
+	if errors.Is(err, fs.ErrNotExist) {
+		s = "expected file to exist\n"
+		s += bullet(" name: %s\n", file)
+		s += bullet("error: %s\n", err)
+		return
+	}
+	if err != nil {
+		s = "got an unexpected error\n"
+		s += bullet("name: %s\n", file)
+		s += bullet("error: %s\n", err)
+		return
+	}
+
+	if info.IsDir() {
+		s = "expected file but is a directory\n"
+		s += bullet("name: %s\n", file)
+		return
+	}
+	return
+}
+
 func FileExistsFS(system fs.FS, file string) (s string) {
 	info, err := fs.Stat(system, file)
 	if errors.Is(err, fs.ErrNotExist) {
@@ -998,6 +1021,21 @@ func FileExistsFS(system fs.FS, file string) (s string) {
 	return
 }
 
+func FileNotExists(file string) (s string) {
+	_, err := os.Stat(file)
+	if err == nil {
+		s = "expected file to not exist\n"
+		s += bullet("name: %s\n", file)
+		return
+	}
+	if !errors.Is(err, fs.ErrNotExist) {
+		s = "expected not existing file but got different error\n"
+		s += bullet("error: %s\n", err)
+		return
+	}
+	return
+}
+
 func FileNotExistsFS(system fs.FS, file string) (s string) {
 	_, err := fs.Stat(system, file)
 	if err == nil {
@@ -1013,9 +1051,9 @@ func FileNotExistsFS(system fs.FS, file string) (s string) {
 	return
 }
 
-func DirExistsFS(system fs.FS, directory string) (s string) {
-	info, err := fs.Stat(system, directory)
-	if os.IsNotExist(err) {
+func DirExists(directory string) (s string) {
+	info, err := os.Stat(directory)
+	if errors.Is(err, fs.ErrNotExist) {
 		s = "expected directory to exist\n"
 		s += bullet(" name: %s\n", directory)
 		s += bullet("error: %s\n", err)
@@ -1029,6 +1067,38 @@ func DirExistsFS(system fs.FS, directory string) (s string) {
 	}
 	if !info.IsDir() {
 		s = "expected directory but is a file\n"
+		s += bullet("name: %s\n", directory)
+		return
+	}
+	return
+}
+
+func DirExistsFS(system fs.FS, directory string) (s string) {
+	info, err := fs.Stat(system, directory)
+	if errors.Is(err, fs.ErrNotExist) {
+		s = "expected directory to exist\n"
+		s += bullet(" name: %s\n", directory)
+		s += bullet("error: %s\n", err)
+		return
+	}
+	if err != nil {
+		s = "got an unexpected error\n"
+		s += bullet("name: %s\n", directory)
+		s += bullet("error: %s\n", err)
+		return
+	}
+	if !info.IsDir() {
+		s = "expected directory but is a file\n"
+		s += bullet("name: %s\n", directory)
+		return
+	}
+	return
+}
+
+func DirNotExists(directory string) (s string) {
+	_, err := os.Stat(directory)
+	if !errors.Is(err, fs.ErrNotExist) {
+		s = "expected directory to not exist\n"
 		s += bullet("name: %s\n", directory)
 		return
 	}
@@ -1083,6 +1153,25 @@ func DirModeFS(system fs.FS, path string, permissions fs.FileMode) (s string) {
 		s += bullet("name: %s\n", path)
 		s += bullet(" exp: %s\n", permissions)
 		s += bullet(" got: %s\n", mode)
+	}
+	return
+}
+
+func FileContains(file, content string) (s string) {
+	b, err := os.ReadFile(file)
+	if err != nil {
+		s = "expected to read file\n"
+		s += bullet(" name: %s\n", file)
+		s += bullet("error: %s\n", err)
+		return
+	}
+	actual := string(b)
+	if !strings.Contains(string(b), content) {
+		s = "expected file contents\n"
+		s += bullet("  name: %s\n", file)
+		s += bullet("wanted: %s\n", content)
+		s += bullet("actual: %s\n", actual)
+		return
 	}
 	return
 }

--- a/internal/assertions/assertions.go
+++ b/internal/assertions/assertions.go
@@ -983,8 +983,13 @@ func FileExistsFS(system fs.FS, file string) (s string) {
 		s += bullet("error: %s\n", err)
 		return
 	}
+	if err != nil {
+		s = "got an unexpected error\n"
+		s += bullet("name: %s\n", file)
+		s += bullet("error: %s\n", err)
+		return
+	}
 
-	// other errors - file probably exists but cannot be read
 	if info.IsDir() {
 		s = "expected file but is a directory\n"
 		s += bullet("name: %s\n", file)
@@ -1016,7 +1021,12 @@ func DirExistsFS(system fs.FS, directory string) (s string) {
 		s += bullet("error: %s\n", err)
 		return
 	}
-	// other errors - directory probably exists but cannot be read
+	if err != nil {
+		s = "got an unexpected error\n"
+		s += bullet("name: %s\n", directory)
+		s += bullet("error: %s\n", err)
+		return
+	}
 	if !info.IsDir() {
 		s = "expected directory but is a file\n"
 		s += bullet("name: %s\n", directory)

--- a/invocations_test.go
+++ b/invocations_test.go
@@ -54,6 +54,15 @@ func (it *internalTest) assert() {
 	}
 }
 
+func (it *internalTest) assertNot() {
+	if !it.helper {
+		it.t.Fatal("should be marked as helper")
+	}
+	if it.trigger {
+		it.t.Fatalf("condition expected not to trigger; it did\ngot message %q in output", it.capture)
+	}
+}
+
 func (it *internalTest) post() {
 	if !strings.Contains(it.capture, "PostScript |") {
 		it.t.Fatal("expected post-script output")

--- a/must/invocations_test.go
+++ b/must/invocations_test.go
@@ -56,6 +56,15 @@ func (it *internalTest) assert() {
 	}
 }
 
+func (it *internalTest) assertNot() {
+	if !it.helper {
+		it.t.Fatal("should be marked as helper")
+	}
+	if it.trigger {
+		it.t.Fatalf("condition expected not to trigger; it did\ngot message %q in output", it.capture)
+	}
+}
+
 func (it *internalTest) post() {
 	if !strings.Contains(it.capture, "PostScript |") {
 		it.t.Fatal("expected post-script output")

--- a/must/must.go
+++ b/must/must.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"io/fs"
 	"os"
-	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -549,9 +548,7 @@ func FileExistsFS(t T, system fs.FS, file string, settings ...Setting) {
 // FileExists asserts file exists on the OS filesystem.
 func FileExists(t T, file string, settings ...Setting) {
 	t.Helper()
-	dir := filepath.Dir(file)
-	file = filepath.Base(file)
-	invoke(t, assertions.FileExistsFS(os.DirFS(dir), file), settings...)
+	invoke(t, assertions.FileExists(file), settings...)
 }
 
 // FileNotExistsFS asserts file does not exist on the fs.FS filesystem.
@@ -566,9 +563,7 @@ func FileNotExistsFS(t T, system fs.FS, file string, settings ...Setting) {
 // FileNotExists asserts file does not exist on the OS filesystem.
 func FileNotExists(t T, file string, settings ...Setting) {
 	t.Helper()
-	dir := filepath.Dir(file)
-	file = filepath.Base(file)
-	invoke(t, assertions.FileNotExistsFS(os.DirFS(dir), file), settings...)
+	invoke(t, assertions.FileNotExists(file), settings...)
 }
 
 // DirExistsFS asserts directory exists on the fs.FS filesystem.
@@ -584,8 +579,7 @@ func DirExistsFS(t T, system fs.FS, directory string, settings ...Setting) {
 // DirExists asserts directory exists on the OS filesystem.
 func DirExists(t T, directory string, settings ...Setting) {
 	t.Helper()
-	directory = strings.TrimPrefix(directory, "/")
-	invoke(t, assertions.DirExistsFS(os.DirFS(brokenfs.Root), directory), settings...)
+	invoke(t, assertions.DirExists(directory), settings...)
 }
 
 // DirNotExistsFS asserts directory does not exist on the fs.FS filesystem.
@@ -600,8 +594,7 @@ func DirNotExistsFS(t T, system fs.FS, directory string, settings ...Setting) {
 // DirNotExists asserts directory does not exist on the OS filesystem.
 func DirNotExists(t T, directory string, settings ...Setting) {
 	t.Helper()
-	directory = strings.TrimPrefix(directory, "/")
-	invoke(t, assertions.DirNotExistsFS(os.DirFS(brokenfs.Root), directory), settings...)
+	invoke(t, assertions.DirNotExists(directory), settings...)
 }
 
 // FileModeFS asserts the file or directory at path on fs.FS has exactly the given permission bits.
@@ -649,8 +642,7 @@ func FileContainsFS(t T, system fs.FS, file, content string, settings ...Setting
 // FileContains asserts the file on the OS filesystem contains content as a substring.
 func FileContains(t T, file, content string, settings ...Setting) {
 	t.Helper()
-	file = strings.TrimPrefix(file, "/")
-	invoke(t, assertions.FileContainsFS(os.DirFS(brokenfs.Root), file, content), settings...)
+	invoke(t, assertions.FileContains(file, content), settings...)
 }
 
 // FilePathValid asserts path is a valid file path.

--- a/must/must_test.go
+++ b/must/must_test.go
@@ -6,9 +6,12 @@
 package must
 
 import (
+	"embed"
 	"errors"
+	"io/fs"
 	"math"
 	"os"
+	"path/filepath"
 	"regexp"
 	"runtime"
 	"testing"
@@ -16,6 +19,10 @@ import (
 
 	"github.com/shoenig/test/wait"
 )
+
+//go:embed testdata/dir1
+var _testdata embed.FS
+var testfs, _ = fs.Sub(_testdata, "testdata")
 
 func needsOS(t *testing.T, os string) {
 	if os != runtime.GOOS {
@@ -1359,64 +1366,66 @@ func TestFileExistsFS(t *testing.T) {
 	tc := newCase(t, `expected file to exist`)
 	t.Cleanup(tc.assert)
 
-	FileExistsFS(tc, os.DirFS("/etc"), "hosts2")
+	FileExistsFS(tc, testfs, "dir1/file2")
 }
 
 func TestFileExists(t *testing.T) {
 	tc := newCase(t, `expected file to exist`)
 	t.Cleanup(tc.assert)
 
-	FileExists(tc, "/etc/hosts2")
+	FileExists(tc, filepath.Join(t.TempDir(), "fake"))
 }
 
 func TestFileNotExistsFS(t *testing.T) {
-	needsOS(t, "linux")
-
 	tc := newCase(t, `expected file to not exist`)
 	t.Cleanup(tc.assert)
 
-	FileNotExistsFS(tc, os.DirFS("/etc"), "hosts")
+	FileNotExistsFS(tc, testfs, "dir1/file1")
+}
+
+func createTempFile(t *testing.T, name string) (path string) {
+	path = filepath.Join(t.TempDir(), name)
+	err := os.WriteFile(path, []byte{}, os.ModePerm)
+	if err != nil {
+		t.Fatal("failed to create temp file")
+	}
+	return path
 }
 
 func TestFileNotExists(t *testing.T) {
-	needsOS(t, "linux")
-
 	tc := newCase(t, `expected file to not exist`)
 	t.Cleanup(tc.assert)
 
-	FileNotExists(tc, "/etc/hosts")
+	path := createTempFile(t, "test")
+	FileNotExists(tc, path)
 }
 
 func TestDirExistsFS(t *testing.T) {
 	tc := newCase(t, `expected directory to exist`)
 	t.Cleanup(tc.assert)
 
-	DirExistsFS(tc, os.DirFS("/usr/local"), "bin2")
+	DirExistsFS(tc, testfs, "dir2")
 }
 
 func TestDirExists(t *testing.T) {
 	tc := newCase(t, `expected directory to exist`)
 	t.Cleanup(tc.assert)
 
-	DirExists(tc, "/usr/local/bin2")
+	DirExists(tc, filepath.Join(t.TempDir(), "fake"))
 }
 
 func TestDirNotExistsFS(t *testing.T) {
-	needsOS(t, "linux")
-
 	tc := newCase(t, `expected directory to not exist`)
 	t.Cleanup(tc.assert)
 
-	DirNotExistsFS(tc, os.DirFS("/usr"), "local")
+	DirNotExistsFS(tc, testfs, "dir1")
 }
 
 func TestDirNotExists(t *testing.T) {
-	needsOS(t, "linux")
-
 	tc := newCase(t, `expected directory to not exist`)
 	t.Cleanup(tc.assert)
 
-	DirNotExists(tc, "/usr/local")
+	DirNotExists(tc, t.TempDir())
 }
 
 func TestFileModeFS(t *testing.T) {
@@ -1478,21 +1487,18 @@ func TestDirMode(t *testing.T) {
 }
 
 func TestFileContainsFS(t *testing.T) {
-	needsOS(t, "linux")
-
 	tc := newCase(t, `expected file contents`)
 	t.Cleanup(tc.assert)
 
-	FileContainsFS(tc, os.DirFS("/etc"), "hosts", "127.0.0.999")
+	FileContainsFS(tc, testfs, "dir1/file1", "fake data")
 }
 
 func TestFileContains(t *testing.T) {
-	needsOS(t, "linux")
-
 	tc := newCase(t, `expected file contents`)
 	t.Cleanup(tc.assert)
 
-	FileContains(tc, "/etc/hosts", "127.0.0.999")
+	path := createTempFile(t, "test")
+	FileContains(tc, path, "fake data")
 }
 
 func TestFilePathValid(t *testing.T) {

--- a/must/must_test.go
+++ b/must/must_test.go
@@ -1362,70 +1362,133 @@ func TestMapNotContainsValueEqual(t *testing.T) {
 	MapNotContainsValueEqual(tc, m, &Person{ID: 200, Name: "Daisy"})
 }
 
-func TestFileExistsFS(t *testing.T) {
-	tc := newCase(t, `expected file to exist`)
-	t.Cleanup(tc.assert)
-
-	FileExistsFS(tc, testfs, "dir1/file2")
-}
-
-func TestFileExists(t *testing.T) {
-	tc := newCase(t, `expected file to exist`)
-	t.Cleanup(tc.assert)
-
-	FileExists(tc, filepath.Join(t.TempDir(), "fake"))
-}
-
-func TestFileNotExistsFS(t *testing.T) {
-	tc := newCase(t, `expected file to not exist`)
-	t.Cleanup(tc.assert)
-
-	FileNotExistsFS(tc, testfs, "dir1/file1")
-}
-
-func createTempFile(t *testing.T, name string) (path string) {
+func writeTempFile(t *testing.T, name, data string) (path string) {
 	path = filepath.Join(t.TempDir(), name)
-	err := os.WriteFile(path, []byte{}, os.ModePerm)
+	err := os.WriteFile(path, []byte(data), os.ModePerm)
 	if err != nil {
 		t.Fatal("failed to create temp file")
 	}
 	return path
 }
 
-func TestFileNotExists(t *testing.T) {
-	tc := newCase(t, `expected file to not exist`)
-	t.Cleanup(tc.assert)
+func TestFileExistsFS(t *testing.T) {
+	t.Run("file does not exist", func(t *testing.T) {
+		tc := newCase(t, `expected file to exist`)
+		t.Cleanup(tc.assert)
 
-	path := createTempFile(t, "test")
-	FileNotExists(tc, path)
+		FileExistsFS(tc, testfs, "dir1/file2")
+	})
+	t.Run("file exists", func(t *testing.T) {
+		tc := newCase(t, "")
+		t.Cleanup(tc.assertNot)
+
+		FileExistsFS(tc, testfs, "dir1/file1")
+	})
+}
+
+func TestFileExists(t *testing.T) {
+	t.Run("file does not exist", func(t *testing.T) {
+		tc := newCase(t, `expected file to exist`)
+		t.Cleanup(tc.assert)
+
+		FileExists(tc, filepath.Join(t.TempDir(), "fake"))
+	})
+	t.Run("file exists", func(t *testing.T) {
+		tc := newCase(t, "")
+		t.Cleanup(tc.assertNot)
+
+		FileExists(tc, writeTempFile(t, "real", ""))
+	})
+}
+
+func TestFileNotExistsFS(t *testing.T) {
+	t.Run("file exists", func(t *testing.T) {
+		tc := newCase(t, `expected file to not exist`)
+		t.Cleanup(tc.assert)
+
+		FileNotExistsFS(tc, testfs, "dir1/file1")
+	})
+	t.Run("file does not exist", func(t *testing.T) {
+		tc := newCase(t, "")
+		t.Cleanup(tc.assertNot)
+
+		FileNotExistsFS(tc, testfs, "dir1/file2")
+	})
+}
+
+func TestFileNotExists(t *testing.T) {
+	t.Run("file exists", func(t *testing.T) {
+		tc := newCase(t, `expected file to not exist`)
+		t.Cleanup(tc.assert)
+
+		FileNotExists(tc, writeTempFile(t, "real", ""))
+	})
+	t.Run("file does not exist", func(t *testing.T) {
+		tc := newCase(t, "")
+		t.Cleanup(tc.assertNot)
+
+		FileNotExists(tc, filepath.Join(t.TempDir(), "fake"))
+	})
 }
 
 func TestDirExistsFS(t *testing.T) {
-	tc := newCase(t, `expected directory to exist`)
-	t.Cleanup(tc.assert)
+	t.Run("dir does not exist", func(t *testing.T) {
+		tc := newCase(t, `expected directory to exist`)
+		t.Cleanup(tc.assert)
 
-	DirExistsFS(tc, testfs, "dir2")
+		DirExistsFS(tc, testfs, "dir2")
+	})
+	t.Run("dir exists", func(t *testing.T) {
+		tc := newCase(t, "")
+		t.Cleanup(tc.assertNot)
+
+		DirExistsFS(tc, testfs, "dir1")
+	})
 }
 
 func TestDirExists(t *testing.T) {
-	tc := newCase(t, `expected directory to exist`)
-	t.Cleanup(tc.assert)
+	t.Run("dir does not exist", func(t *testing.T) {
+		tc := newCase(t, `expected directory to exist`)
+		t.Cleanup(tc.assert)
 
-	DirExists(tc, filepath.Join(t.TempDir(), "fake"))
+		DirExists(tc, filepath.Join(t.TempDir(), "fake"))
+	})
+	t.Run("dir exists", func(t *testing.T) {
+		tc := newCase(t, "")
+		t.Cleanup(tc.assertNot)
+
+		DirExists(tc, t.TempDir())
+	})
 }
 
 func TestDirNotExistsFS(t *testing.T) {
-	tc := newCase(t, `expected directory to not exist`)
-	t.Cleanup(tc.assert)
+	t.Run("dir exists", func(t *testing.T) {
+		tc := newCase(t, `expected directory to not exist`)
+		t.Cleanup(tc.assert)
 
-	DirNotExistsFS(tc, testfs, "dir1")
+		DirNotExistsFS(tc, testfs, "dir1")
+	})
+	t.Run("dir does not exist", func(t *testing.T) {
+		tc := newCase(t, "")
+		t.Cleanup(tc.assertNot)
+
+		DirNotExistsFS(tc, testfs, "dir2")
+	})
 }
 
 func TestDirNotExists(t *testing.T) {
-	tc := newCase(t, `expected directory to not exist`)
-	t.Cleanup(tc.assert)
+	t.Run("dir exists", func(t *testing.T) {
+		tc := newCase(t, `expected directory to not exist`)
+		t.Cleanup(tc.assert)
 
-	DirNotExists(tc, t.TempDir())
+		DirNotExists(tc, t.TempDir())
+	})
+	t.Run("dir does not exist", func(t *testing.T) {
+		tc := newCase(t, "")
+		t.Cleanup(tc.assertNot)
+
+		DirNotExists(tc, filepath.Join(t.TempDir(), "fake"))
+	})
 }
 
 func TestFileModeFS(t *testing.T) {
@@ -1487,18 +1550,33 @@ func TestDirMode(t *testing.T) {
 }
 
 func TestFileContainsFS(t *testing.T) {
-	tc := newCase(t, `expected file contents`)
-	t.Cleanup(tc.assert)
+	t.Run("file does not contain data", func(t *testing.T) {
+		tc := newCase(t, `expected file contents`)
+		t.Cleanup(tc.assert)
 
-	FileContainsFS(tc, testfs, "dir1/file1", "fake data")
+		FileContainsFS(tc, testfs, "dir1/file1", "fake")
+	})
+	t.Run("file contains data", func(t *testing.T) {
+		tc := newCase(t, "")
+		t.Cleanup(tc.assertNot)
+
+		FileContainsFS(tc, testfs, "dir1/file1", "real")
+	})
 }
 
 func TestFileContains(t *testing.T) {
-	tc := newCase(t, `expected file contents`)
-	t.Cleanup(tc.assert)
+	t.Run("file does not contain data", func(t *testing.T) {
+		tc := newCase(t, `expected file contents`)
+		t.Cleanup(tc.assert)
 
-	path := createTempFile(t, "test")
-	FileContains(tc, path, "fake data")
+		FileContains(tc, writeTempFile(t, "test", "real data"), "fake")
+	})
+	t.Run("file contains data", func(t *testing.T) {
+		tc := newCase(t, "")
+		t.Cleanup(tc.assertNot)
+
+		FileContains(tc, writeTempFile(t, "test", "real data"), "real")
+	})
 }
 
 func TestFilePathValid(t *testing.T) {

--- a/must/testdata/dir1/file1
+++ b/must/testdata/dir1/file1
@@ -1,0 +1,1 @@
+real data

--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -20,6 +20,8 @@ apply test.go
 apply test_test.go
 apply examples_test.go
 
+cp -R testdata must/
+
 # rename core test files
 mv must/test.go must/must.go
 mv must/test_test.go must/must_test.go

--- a/test.go
+++ b/test.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"io/fs"
 	"os"
-	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -547,9 +546,7 @@ func FileExistsFS(t T, system fs.FS, file string, settings ...Setting) {
 // FileExists asserts file exists on the OS filesystem.
 func FileExists(t T, file string, settings ...Setting) {
 	t.Helper()
-	dir := filepath.Dir(file)
-	file = filepath.Base(file)
-	invoke(t, assertions.FileExistsFS(os.DirFS(dir), file), settings...)
+	invoke(t, assertions.FileExists(file), settings...)
 }
 
 // FileNotExistsFS asserts file does not exist on the fs.FS filesystem.
@@ -564,9 +561,7 @@ func FileNotExistsFS(t T, system fs.FS, file string, settings ...Setting) {
 // FileNotExists asserts file does not exist on the OS filesystem.
 func FileNotExists(t T, file string, settings ...Setting) {
 	t.Helper()
-	dir := filepath.Dir(file)
-	file = filepath.Base(file)
-	invoke(t, assertions.FileNotExistsFS(os.DirFS(dir), file), settings...)
+	invoke(t, assertions.FileNotExists(file), settings...)
 }
 
 // DirExistsFS asserts directory exists on the fs.FS filesystem.
@@ -582,8 +577,7 @@ func DirExistsFS(t T, system fs.FS, directory string, settings ...Setting) {
 // DirExists asserts directory exists on the OS filesystem.
 func DirExists(t T, directory string, settings ...Setting) {
 	t.Helper()
-	directory = strings.TrimPrefix(directory, "/")
-	invoke(t, assertions.DirExistsFS(os.DirFS(brokenfs.Root), directory), settings...)
+	invoke(t, assertions.DirExists(directory), settings...)
 }
 
 // DirNotExistsFS asserts directory does not exist on the fs.FS filesystem.
@@ -598,8 +592,7 @@ func DirNotExistsFS(t T, system fs.FS, directory string, settings ...Setting) {
 // DirNotExists asserts directory does not exist on the OS filesystem.
 func DirNotExists(t T, directory string, settings ...Setting) {
 	t.Helper()
-	directory = strings.TrimPrefix(directory, "/")
-	invoke(t, assertions.DirNotExistsFS(os.DirFS(brokenfs.Root), directory), settings...)
+	invoke(t, assertions.DirNotExists(directory), settings...)
 }
 
 // FileModeFS asserts the file or directory at path on fs.FS has exactly the given permission bits.
@@ -647,8 +640,7 @@ func FileContainsFS(t T, system fs.FS, file, content string, settings ...Setting
 // FileContains asserts the file on the OS filesystem contains content as a substring.
 func FileContains(t T, file, content string, settings ...Setting) {
 	t.Helper()
-	file = strings.TrimPrefix(file, "/")
-	invoke(t, assertions.FileContainsFS(os.DirFS(brokenfs.Root), file, content), settings...)
+	invoke(t, assertions.FileContains(file, content), settings...)
 }
 
 // FilePathValid asserts path is a valid file path.

--- a/test_test.go
+++ b/test_test.go
@@ -1360,70 +1360,133 @@ func TestMapNotContainsValueEqual(t *testing.T) {
 	MapNotContainsValueEqual(tc, m, &Person{ID: 200, Name: "Daisy"})
 }
 
-func TestFileExistsFS(t *testing.T) {
-	tc := newCase(t, `expected file to exist`)
-	t.Cleanup(tc.assert)
-
-	FileExistsFS(tc, testfs, "dir1/file2")
-}
-
-func TestFileExists(t *testing.T) {
-	tc := newCase(t, `expected file to exist`)
-	t.Cleanup(tc.assert)
-
-	FileExists(tc, filepath.Join(t.TempDir(), "fake"))
-}
-
-func TestFileNotExistsFS(t *testing.T) {
-	tc := newCase(t, `expected file to not exist`)
-	t.Cleanup(tc.assert)
-
-	FileNotExistsFS(tc, testfs, "dir1/file1")
-}
-
-func createTempFile(t *testing.T, name string) (path string) {
+func writeTempFile(t *testing.T, name, data string) (path string) {
 	path = filepath.Join(t.TempDir(), name)
-	err := os.WriteFile(path, []byte{}, os.ModePerm)
+	err := os.WriteFile(path, []byte(data), os.ModePerm)
 	if err != nil {
 		t.Fatal("failed to create temp file")
 	}
 	return path
 }
 
-func TestFileNotExists(t *testing.T) {
-	tc := newCase(t, `expected file to not exist`)
-	t.Cleanup(tc.assert)
+func TestFileExistsFS(t *testing.T) {
+	t.Run("file does not exist", func(t *testing.T) {
+		tc := newCase(t, `expected file to exist`)
+		t.Cleanup(tc.assert)
 
-	path := createTempFile(t, "test")
-	FileNotExists(tc, path)
+		FileExistsFS(tc, testfs, "dir1/file2")
+	})
+	t.Run("file exists", func(t *testing.T) {
+		tc := newCase(t, "")
+		t.Cleanup(tc.assertNot)
+
+		FileExistsFS(tc, testfs, "dir1/file1")
+	})
+}
+
+func TestFileExists(t *testing.T) {
+	t.Run("file does not exist", func(t *testing.T) {
+		tc := newCase(t, `expected file to exist`)
+		t.Cleanup(tc.assert)
+
+		FileExists(tc, filepath.Join(t.TempDir(), "fake"))
+	})
+	t.Run("file exists", func(t *testing.T) {
+		tc := newCase(t, "")
+		t.Cleanup(tc.assertNot)
+
+		FileExists(tc, writeTempFile(t, "real", ""))
+	})
+}
+
+func TestFileNotExistsFS(t *testing.T) {
+	t.Run("file exists", func(t *testing.T) {
+		tc := newCase(t, `expected file to not exist`)
+		t.Cleanup(tc.assert)
+
+		FileNotExistsFS(tc, testfs, "dir1/file1")
+	})
+	t.Run("file does not exist", func(t *testing.T) {
+		tc := newCase(t, "")
+		t.Cleanup(tc.assertNot)
+
+		FileNotExistsFS(tc, testfs, "dir1/file2")
+	})
+}
+
+func TestFileNotExists(t *testing.T) {
+	t.Run("file exists", func(t *testing.T) {
+		tc := newCase(t, `expected file to not exist`)
+		t.Cleanup(tc.assert)
+
+		FileNotExists(tc, writeTempFile(t, "real", ""))
+	})
+	t.Run("file does not exist", func(t *testing.T) {
+		tc := newCase(t, "")
+		t.Cleanup(tc.assertNot)
+
+		FileNotExists(tc, filepath.Join(t.TempDir(), "fake"))
+	})
 }
 
 func TestDirExistsFS(t *testing.T) {
-	tc := newCase(t, `expected directory to exist`)
-	t.Cleanup(tc.assert)
+	t.Run("dir does not exist", func(t *testing.T) {
+		tc := newCase(t, `expected directory to exist`)
+		t.Cleanup(tc.assert)
 
-	DirExistsFS(tc, testfs, "dir2")
+		DirExistsFS(tc, testfs, "dir2")
+	})
+	t.Run("dir exists", func(t *testing.T) {
+		tc := newCase(t, "")
+		t.Cleanup(tc.assertNot)
+
+		DirExistsFS(tc, testfs, "dir1")
+	})
 }
 
 func TestDirExists(t *testing.T) {
-	tc := newCase(t, `expected directory to exist`)
-	t.Cleanup(tc.assert)
+	t.Run("dir does not exist", func(t *testing.T) {
+		tc := newCase(t, `expected directory to exist`)
+		t.Cleanup(tc.assert)
 
-	DirExists(tc, filepath.Join(t.TempDir(), "fake"))
+		DirExists(tc, filepath.Join(t.TempDir(), "fake"))
+	})
+	t.Run("dir exists", func(t *testing.T) {
+		tc := newCase(t, "")
+		t.Cleanup(tc.assertNot)
+
+		DirExists(tc, t.TempDir())
+	})
 }
 
 func TestDirNotExistsFS(t *testing.T) {
-	tc := newCase(t, `expected directory to not exist`)
-	t.Cleanup(tc.assert)
+	t.Run("dir exists", func(t *testing.T) {
+		tc := newCase(t, `expected directory to not exist`)
+		t.Cleanup(tc.assert)
 
-	DirNotExistsFS(tc, testfs, "dir1")
+		DirNotExistsFS(tc, testfs, "dir1")
+	})
+	t.Run("dir does not exist", func(t *testing.T) {
+		tc := newCase(t, "")
+		t.Cleanup(tc.assertNot)
+
+		DirNotExistsFS(tc, testfs, "dir2")
+	})
 }
 
 func TestDirNotExists(t *testing.T) {
-	tc := newCase(t, `expected directory to not exist`)
-	t.Cleanup(tc.assert)
+	t.Run("dir exists", func(t *testing.T) {
+		tc := newCase(t, `expected directory to not exist`)
+		t.Cleanup(tc.assert)
 
-	DirNotExists(tc, t.TempDir())
+		DirNotExists(tc, t.TempDir())
+	})
+	t.Run("dir does not exist", func(t *testing.T) {
+		tc := newCase(t, "")
+		t.Cleanup(tc.assertNot)
+
+		DirNotExists(tc, filepath.Join(t.TempDir(), "fake"))
+	})
 }
 
 func TestFileModeFS(t *testing.T) {
@@ -1485,18 +1548,33 @@ func TestDirMode(t *testing.T) {
 }
 
 func TestFileContainsFS(t *testing.T) {
-	tc := newCase(t, `expected file contents`)
-	t.Cleanup(tc.assert)
+	t.Run("file does not contain data", func(t *testing.T) {
+		tc := newCase(t, `expected file contents`)
+		t.Cleanup(tc.assert)
 
-	FileContainsFS(tc, testfs, "dir1/file1", "fake data")
+		FileContainsFS(tc, testfs, "dir1/file1", "fake")
+	})
+	t.Run("file contains data", func(t *testing.T) {
+		tc := newCase(t, "")
+		t.Cleanup(tc.assertNot)
+
+		FileContainsFS(tc, testfs, "dir1/file1", "real")
+	})
 }
 
 func TestFileContains(t *testing.T) {
-	tc := newCase(t, `expected file contents`)
-	t.Cleanup(tc.assert)
+	t.Run("file does not contain data", func(t *testing.T) {
+		tc := newCase(t, `expected file contents`)
+		t.Cleanup(tc.assert)
 
-	path := createTempFile(t, "test")
-	FileContains(tc, path, "fake data")
+		FileContains(tc, writeTempFile(t, "test", "real data"), "fake")
+	})
+	t.Run("file contains data", func(t *testing.T) {
+		tc := newCase(t, "")
+		t.Cleanup(tc.assertNot)
+
+		FileContains(tc, writeTempFile(t, "test", "real data"), "real")
+	})
 }
 
 func TestFilePathValid(t *testing.T) {

--- a/testdata/dir1/file1
+++ b/testdata/dir1/file1
@@ -1,0 +1,1 @@
+real data


### PR DESCRIPTION
File and directory helpers don't work properly on Windows, and a couple of them even panic. This PR fixes a few underlying problems:

1. `os.DirFS` does not handle Windows paths properly, and `brokenfs` isn't doing the trick to fix it. When those functions validate names, they choke on the colon after the drive letter and return `fs.ErrInvalid`. Perhaps this can be avoided by not providing a drive letter (that seems to be a solution given in https://github.com/golang/go/issues/44279) but that's inconvenient and would probably only work if the file/directory is on the same drive as the working directory. I fixed this by adding having the non-FS helpers use new assertions that call `os` functions instead of `fs` ones.

2. Some file and directory assertions only check for `ErrNotExist` and then assume that `Stat` succeeded. In the best case, this misses an uncaught `ErrInvalid` and gives a misleading result; in the worst case, as in `FileExistsFS` and `DirExistsFS`, it leads to a panic from a nil dereference. I prevented the panics by checking for other errors as well before dereferencing the `Stat` result.

3. There are no tests in the test suite that make sure an assertion _wasn't_ triggered, and some of the tests that do exist get skipped on Windows. I updated the tests to check both major paths, and I made most of the tests Windows-compatible by using `t.TempDir()` instead of standard Unix paths. I didn't do this to the `FileMode` and `DirMode` tests because I don't know how Unix permissions work on Windows.