### PR TITLE
test: add ErrorAs helper and fix up examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ There are five key packages,
 :ballot_box_with_check: v1.11.0 adds an ErrorAs helper
 
  - FS examples are more reliable
+ - Examples run on non-Unix OS when possible
 
 :ballot_box_with_check: v1.10.0 adds a `util` package for helpers that return values
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ There are five key packages,
 ### Changes
 :ballot_box_with_check: v1.11.0 adds an ErrorAs helper
 
+ - FS examples are more reliable
+
 :ballot_box_with_check: v1.10.0 adds a `util` package for helpers that return values
 
  - Adds ability to create and automatically clean up temporary files

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ There are five key packages,
 - `portal` - utilities for allocating free ports for network listeners in tests
 
 ### Changes
+:ballot_box_with_check: v1.11.0 adds an ErrorAs helper
+
 :ballot_box_with_check: v1.10.0 adds a `util` package for helpers that return values
 
  - Adds ability to create and automatically clean up temporary files

--- a/examples_test.go
+++ b/examples_test.go
@@ -1,8 +1,6 @@
 // Copyright (c) The Test Authors
 // SPDX-License-Identifier: MPL-2.0
 
-//go:build unix
-
 package test
 
 import (
@@ -10,7 +8,6 @@ import (
 	"fmt"
 	"io/fs"
 	"math"
-	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -226,21 +223,11 @@ func ExampleDescendingLess() {
 	// Output:
 }
 
-func ExampleDirExists() {
-	DirExists(t, "/tmp")
-	// Output:
-}
-
 func ExampleDirExistsFS() {
 	fsys := fstest.MapFS{
 		"foo": &fstest.MapFile{Mode: fs.ModeDir},
 	}
 	DirExistsFS(t, fsys, "foo")
-	// Output:
-}
-
-func ExampleDirNotExists() {
-	DirNotExists(t, "/does/not/exist")
 	// Output:
 }
 
@@ -339,12 +326,6 @@ func ExampleFalse() {
 	// Output:
 }
 
-func ExampleFileContains() {
-	_ = os.WriteFile("/tmp/example", []byte("foo bar baz"), fs.FileMode(0600))
-	FileContains(t, "/tmp/example", "bar")
-	// Output:
-}
-
 func ExampleFileContainsFS() {
 	fsys := fstest.MapFS{
 		"example": &fstest.MapFile{
@@ -352,12 +333,6 @@ func ExampleFileContainsFS() {
 		},
 	}
 	FileContainsFS(t, fsys, "example", "bar")
-	// Output:
-}
-
-func ExampleFileExists() {
-	_ = os.WriteFile("/tmp/example", []byte{}, fs.FileMode(0600))
-	FileExists(t, "/tmp/example")
 	// Output:
 }
 
@@ -369,22 +344,11 @@ func ExampleFileExistsFS() {
 	// Output:
 }
 
-func ExampleFileMode() {
-	_ = os.WriteFile("/tmp/example_fm", []byte{}, fs.FileMode(0600))
-	FileMode(t, "/tmp/example_fm", fs.FileMode(0600))
-	// Output:
-}
-
 func ExampleFileModeFS() {
 	fsys := fstest.MapFS{
 		"example": &fstest.MapFile{Mode: 0600},
 	}
 	FileModeFS(t, fsys, "example", fs.FileMode(0600))
-	// Output:
-}
-
-func ExampleFileNotExists() {
-	FileNotExists(t, "/tmp/not_existing_file")
 	// Output:
 }
 

--- a/examples_test.go
+++ b/examples_test.go
@@ -14,6 +14,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"testing/fstest"
 	"time"
 
 	"github.com/shoenig/test/wait"
@@ -231,7 +232,10 @@ func ExampleDirExists() {
 }
 
 func ExampleDirExistsFS() {
-	DirExistsFS(t, os.DirFS("/"), "tmp")
+	fsys := fstest.MapFS{
+		"foo": &fstest.MapFile{Mode: fs.ModeDir},
+	}
+	DirExistsFS(t, fsys, "foo")
 	// Output:
 }
 
@@ -241,7 +245,8 @@ func ExampleDirNotExists() {
 }
 
 func ExampleDirNotExistsFS() {
-	DirNotExistsFS(t, os.DirFS("/"), "does/not/exist")
+	fsys := fstest.MapFS{}
+	DirNotExistsFS(t, fsys, "does/not/exist")
 	// Output:
 }
 
@@ -341,8 +346,12 @@ func ExampleFileContains() {
 }
 
 func ExampleFileContainsFS() {
-	_ = os.WriteFile("/tmp/example", []byte("foo bar baz"), fs.FileMode(0600))
-	FileContainsFS(t, os.DirFS("/tmp"), "example", "bar")
+	fsys := fstest.MapFS{
+		"example": &fstest.MapFile{
+			Data: []byte("foo bar baz"),
+		},
+	}
+	FileContainsFS(t, fsys, "example", "bar")
 	// Output:
 }
 
@@ -353,8 +362,10 @@ func ExampleFileExists() {
 }
 
 func ExampleFileExistsFS() {
-	_ = os.WriteFile("/tmp/example", []byte{}, fs.FileMode(0600))
-	FileExistsFS(t, os.DirFS("/tmp"), "example")
+	fsys := fstest.MapFS{
+		"example": &fstest.MapFile{},
+	}
+	FileExistsFS(t, fsys, "example")
 	// Output:
 }
 
@@ -365,8 +376,10 @@ func ExampleFileMode() {
 }
 
 func ExampleFileModeFS() {
-	_ = os.WriteFile("/tmp/example_fm", []byte{}, fs.FileMode(0600))
-	FileModeFS(t, os.DirFS("/tmp"), "example_fm", fs.FileMode(0600))
+	fsys := fstest.MapFS{
+		"example": &fstest.MapFile{Mode: 0600},
+	}
+	FileModeFS(t, fsys, "example", fs.FileMode(0600))
 	// Output:
 }
 
@@ -376,7 +389,8 @@ func ExampleFileNotExists() {
 }
 
 func ExampleFileNotExistsFS() {
-	FileNotExistsFS(t, os.DirFS("/tmp"), "not_existing_file")
+	fsys := fstest.MapFS{}
+	FileNotExistsFS(t, fsys, "not_existing_file")
 	// Output:
 }
 

--- a/examples_test.go
+++ b/examples_test.go
@@ -318,6 +318,17 @@ func ExampleErrorIs() {
 	// Output:
 }
 
+func ExampleErrorAs() {
+	e1 := errors.New("e1")
+	e2 := FakeError("foo")
+	e3 := errors.New("e3")
+	errorChain := errors.Join(e1, e2, e3)
+	var target FakeError
+	ErrorAs(t, errorChain, &target)
+	fmt.Println(target.Error())
+	// Output: foo
+}
+
 func ExampleFalse() {
 	False(t, 1 == int('a'))
 	// Output:

--- a/examples_unix_test.go
+++ b/examples_unix_test.go
@@ -1,0 +1,44 @@
+// Copyright (c) The Test Authors
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build unix
+
+package test
+
+import (
+	"io/fs"
+	"os"
+)
+
+func ExampleDirExists() {
+	DirExists(t, "/tmp")
+	// Output:
+}
+
+func ExampleDirNotExists() {
+	DirNotExists(t, "/does/not/exist")
+	// Output:
+}
+
+func ExampleFileContains() {
+	_ = os.WriteFile("/tmp/example", []byte("foo bar baz"), fs.FileMode(0600))
+	FileContains(t, "/tmp/example", "bar")
+	// Output:
+}
+
+func ExampleFileExists() {
+	_ = os.WriteFile("/tmp/example", []byte{}, fs.FileMode(0600))
+	FileExists(t, "/tmp/example")
+	// Output:
+}
+
+func ExampleFileMode() {
+	_ = os.WriteFile("/tmp/example_fm", []byte{}, fs.FileMode(0600))
+	FileMode(t, "/tmp/example_fm", fs.FileMode(0600))
+	// Output:
+}
+
+func ExampleFileNotExists() {
+	FileNotExists(t, "/tmp/not_existing_file")
+	// Output:
+}

--- a/internal/assertions/assertions.go
+++ b/internal/assertions/assertions.go
@@ -162,6 +162,23 @@ func ErrorIs(err error, target error) (s string) {
 	return
 }
 
+func ErrorAs[E error, Target *E](err error, target Target) (s string) {
+	if err == nil {
+		s = "expected error; got nil\n"
+		return
+	}
+	if target == nil {
+		s = "expected target not to be nil"
+		return
+	}
+	if !errors.As(err, target) {
+		s = "expected errors.As match\n"
+		s += bullet(" error: %v\n", err)
+		s += bullet("target: %v\n", target)
+	}
+	return
+}
+
 func NoError(err error) (s string) {
 	if err != nil {
 		s = "expected nil error\n"

--- a/must/examples_test.go
+++ b/must/examples_test.go
@@ -320,6 +320,17 @@ func ExampleErrorIs() {
 	// Output:
 }
 
+func ExampleErrorAs() {
+	e1 := errors.New("e1")
+	e2 := FakeError("foo")
+	e3 := errors.New("e3")
+	errorChain := errors.Join(e1, e2, e3)
+	var target FakeError
+	ErrorAs(t, errorChain, &target)
+	fmt.Println(target.Error())
+	// Output: foo
+}
+
 func ExampleFalse() {
 	False(t, 1 == int('a'))
 	// Output:

--- a/must/examples_test.go
+++ b/must/examples_test.go
@@ -3,8 +3,6 @@
 // Copyright (c) The Test Authors
 // SPDX-License-Identifier: MPL-2.0
 
-//go:build unix
-
 package must
 
 import (
@@ -12,7 +10,6 @@ import (
 	"fmt"
 	"io/fs"
 	"math"
-	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -228,21 +225,11 @@ func ExampleDescendingLess() {
 	// Output:
 }
 
-func ExampleDirExists() {
-	DirExists(t, "/tmp")
-	// Output:
-}
-
 func ExampleDirExistsFS() {
 	fsys := fstest.MapFS{
 		"foo": &fstest.MapFile{Mode: fs.ModeDir},
 	}
 	DirExistsFS(t, fsys, "foo")
-	// Output:
-}
-
-func ExampleDirNotExists() {
-	DirNotExists(t, "/does/not/exist")
 	// Output:
 }
 
@@ -341,12 +328,6 @@ func ExampleFalse() {
 	// Output:
 }
 
-func ExampleFileContains() {
-	_ = os.WriteFile("/tmp/example", []byte("foo bar baz"), fs.FileMode(0600))
-	FileContains(t, "/tmp/example", "bar")
-	// Output:
-}
-
 func ExampleFileContainsFS() {
 	fsys := fstest.MapFS{
 		"example": &fstest.MapFile{
@@ -354,12 +335,6 @@ func ExampleFileContainsFS() {
 		},
 	}
 	FileContainsFS(t, fsys, "example", "bar")
-	// Output:
-}
-
-func ExampleFileExists() {
-	_ = os.WriteFile("/tmp/example", []byte{}, fs.FileMode(0600))
-	FileExists(t, "/tmp/example")
 	// Output:
 }
 
@@ -371,22 +346,11 @@ func ExampleFileExistsFS() {
 	// Output:
 }
 
-func ExampleFileMode() {
-	_ = os.WriteFile("/tmp/example_fm", []byte{}, fs.FileMode(0600))
-	FileMode(t, "/tmp/example_fm", fs.FileMode(0600))
-	// Output:
-}
-
 func ExampleFileModeFS() {
 	fsys := fstest.MapFS{
 		"example": &fstest.MapFile{Mode: 0600},
 	}
 	FileModeFS(t, fsys, "example", fs.FileMode(0600))
-	// Output:
-}
-
-func ExampleFileNotExists() {
-	FileNotExists(t, "/tmp/not_existing_file")
 	// Output:
 }
 

--- a/must/examples_test.go
+++ b/must/examples_test.go
@@ -16,6 +16,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"testing/fstest"
 	"time"
 
 	"github.com/shoenig/test/wait"
@@ -233,7 +234,10 @@ func ExampleDirExists() {
 }
 
 func ExampleDirExistsFS() {
-	DirExistsFS(t, os.DirFS("/"), "tmp")
+	fsys := fstest.MapFS{
+		"foo": &fstest.MapFile{Mode: fs.ModeDir},
+	}
+	DirExistsFS(t, fsys, "foo")
 	// Output:
 }
 
@@ -243,7 +247,8 @@ func ExampleDirNotExists() {
 }
 
 func ExampleDirNotExistsFS() {
-	DirNotExistsFS(t, os.DirFS("/"), "does/not/exist")
+	fsys := fstest.MapFS{}
+	DirNotExistsFS(t, fsys, "does/not/exist")
 	// Output:
 }
 
@@ -343,8 +348,12 @@ func ExampleFileContains() {
 }
 
 func ExampleFileContainsFS() {
-	_ = os.WriteFile("/tmp/example", []byte("foo bar baz"), fs.FileMode(0600))
-	FileContainsFS(t, os.DirFS("/tmp"), "example", "bar")
+	fsys := fstest.MapFS{
+		"example": &fstest.MapFile{
+			Data: []byte("foo bar baz"),
+		},
+	}
+	FileContainsFS(t, fsys, "example", "bar")
 	// Output:
 }
 
@@ -355,8 +364,10 @@ func ExampleFileExists() {
 }
 
 func ExampleFileExistsFS() {
-	_ = os.WriteFile("/tmp/example", []byte{}, fs.FileMode(0600))
-	FileExistsFS(t, os.DirFS("/tmp"), "example")
+	fsys := fstest.MapFS{
+		"example": &fstest.MapFile{},
+	}
+	FileExistsFS(t, fsys, "example")
 	// Output:
 }
 
@@ -367,8 +378,10 @@ func ExampleFileMode() {
 }
 
 func ExampleFileModeFS() {
-	_ = os.WriteFile("/tmp/example_fm", []byte{}, fs.FileMode(0600))
-	FileModeFS(t, os.DirFS("/tmp"), "example_fm", fs.FileMode(0600))
+	fsys := fstest.MapFS{
+		"example": &fstest.MapFile{Mode: 0600},
+	}
+	FileModeFS(t, fsys, "example", fs.FileMode(0600))
 	// Output:
 }
 
@@ -378,7 +391,8 @@ func ExampleFileNotExists() {
 }
 
 func ExampleFileNotExistsFS() {
-	FileNotExistsFS(t, os.DirFS("/tmp"), "not_existing_file")
+	fsys := fstest.MapFS{}
+	FileNotExistsFS(t, fsys, "not_existing_file")
 	// Output:
 }
 

--- a/must/examples_unix_test.go
+++ b/must/examples_unix_test.go
@@ -1,0 +1,46 @@
+// Code generated via scripts/generate.sh. DO NOT EDIT.
+
+// Copyright (c) The Test Authors
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build unix
+
+package must
+
+import (
+	"io/fs"
+	"os"
+)
+
+func ExampleDirExists() {
+	DirExists(t, "/tmp")
+	// Output:
+}
+
+func ExampleDirNotExists() {
+	DirNotExists(t, "/does/not/exist")
+	// Output:
+}
+
+func ExampleFileContains() {
+	_ = os.WriteFile("/tmp/example", []byte("foo bar baz"), fs.FileMode(0600))
+	FileContains(t, "/tmp/example", "bar")
+	// Output:
+}
+
+func ExampleFileExists() {
+	_ = os.WriteFile("/tmp/example", []byte{}, fs.FileMode(0600))
+	FileExists(t, "/tmp/example")
+	// Output:
+}
+
+func ExampleFileMode() {
+	_ = os.WriteFile("/tmp/example_fm", []byte{}, fs.FileMode(0600))
+	FileMode(t, "/tmp/example_fm", fs.FileMode(0600))
+	// Output:
+}
+
+func ExampleFileNotExists() {
+	FileNotExists(t, "/tmp/not_existing_file")
+	// Output:
+}

--- a/must/must.go
+++ b/must/must.go
@@ -69,6 +69,13 @@ func ErrorIs(t T, err error, target error, settings ...Setting) {
 	invoke(t, assertions.ErrorIs(err, target), settings...)
 }
 
+// ErrorAs asserts err's tree contains an error that matches target.
+// If so, it sets target to the error value.
+func ErrorAs[E error, Target *E](t T, err error, target Target, settings ...Setting) {
+	t.Helper()
+	invoke(t, assertions.ErrorAs(err, target), settings...)
+}
+
 // NoError asserts err is a nil error.
 func NoError(t T, err error, settings ...Setting) {
 	t.Helper()

--- a/must/must_test.go
+++ b/must/must_test.go
@@ -165,6 +165,38 @@ func TestErrorIs_nil(t *testing.T) {
 	ErrorIs(tc, nil, err)
 }
 
+type FakeError string
+
+func (e FakeError) Error() string {
+	return string(e)
+}
+
+func TestErrorAs(t *testing.T) {
+	tc := newCase(t, `expected errors.As match`)
+	t.Cleanup(tc.assert)
+
+	var target FakeError
+	e := errors.New("foo")
+	ErrorAs(tc, e, &target)
+}
+
+func TestErrorAs_nilErr(t *testing.T) {
+	tc := newCase(t, `expected error; got nil`)
+	t.Cleanup(tc.assert)
+
+	var target FakeError
+	ErrorAs(tc, nil, &target)
+}
+
+func TestErrorAs_nilTarget(t *testing.T) {
+	tc := newCase(t, `expected target not to be nil`)
+	t.Cleanup(tc.assert)
+
+	var target *FakeError
+	e := errors.New("foo")
+	ErrorAs(tc, e, target)
+}
+
 func TestNoError(t *testing.T) {
 	tc := newCase(t, `expected nil error`)
 	t.Cleanup(tc.assert)

--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -19,6 +19,7 @@ apply scripts_test.go
 apply test.go
 apply test_test.go
 apply examples_test.go
+apply examples_unix_test.go
 
 cp -R testdata must/
 

--- a/test.go
+++ b/test.go
@@ -67,6 +67,13 @@ func ErrorIs(t T, err error, target error, settings ...Setting) {
 	invoke(t, assertions.ErrorIs(err, target), settings...)
 }
 
+// ErrorAs asserts err's tree contains an error that matches target.
+// If so, it sets target to the error value.
+func ErrorAs[E error, Target *E](t T, err error, target Target, settings ...Setting) {
+	t.Helper()
+	invoke(t, assertions.ErrorAs(err, target), settings...)
+}
+
 // NoError asserts err is a nil error.
 func NoError(t T, err error, settings ...Setting) {
 	t.Helper()

--- a/test_test.go
+++ b/test_test.go
@@ -163,6 +163,38 @@ func TestErrorIs_nil(t *testing.T) {
 	ErrorIs(tc, nil, err)
 }
 
+type FakeError string
+
+func (e FakeError) Error() string {
+	return string(e)
+}
+
+func TestErrorAs(t *testing.T) {
+	tc := newCase(t, `expected errors.As match`)
+	t.Cleanup(tc.assert)
+
+	var target FakeError
+	e := errors.New("foo")
+	ErrorAs(tc, e, &target)
+}
+
+func TestErrorAs_nilErr(t *testing.T) {
+	tc := newCase(t, `expected error; got nil`)
+	t.Cleanup(tc.assert)
+
+	var target FakeError
+	ErrorAs(tc, nil, &target)
+}
+
+func TestErrorAs_nilTarget(t *testing.T) {
+	tc := newCase(t, `expected target not to be nil`)
+	t.Cleanup(tc.assert)
+
+	var target *FakeError
+	e := errors.New("foo")
+	ErrorAs(tc, e, target)
+}
+
 func TestNoError(t *testing.T) {
 	tc := newCase(t, `expected nil error`)
 	t.Cleanup(tc.assert)


### PR DESCRIPTION
This adds an `ErrorAs` helper using `errors.As`. I've also been getting intermittent failures from FS examples on WSL, so I changed them to us `fstest.MapFS` instead of actual files. And while I was working on that, I noticed that VSCode on Windows was only pretending to run the examples because of their GOOS=unix build constraint, so I applied the constraint to only the examples that needed it.