### PR TITLE
skip: increase test case minimum cores

### DIFF
--- a/skip/skip_test.go
+++ b/skip/skip_test.go
@@ -61,7 +61,7 @@ func TestSkip_CommandUnavailable(t *testing.T) {
 }
 
 func TestSkip_MinimumCores(t *testing.T) {
-	MinimumCores(t, 200)
+	MinimumCores(t, 2048)
 	t.Fatal("expected to skip test")
 }
 


### PR DESCRIPTION
This PR increases the expected minimum cores test core count, because it
fails on this machine I am working on right now with 256 virtual cores.

```
kingpin ~
➜ lscpu | grep On-line
On-line CPU(s) list:                  0-255
```
