### PR TITLE
test: ErrorIs should support having both err and target be nil

### DIFF
--- a/internal/assertions/assertions.go
+++ b/internal/assertions/assertions.go
@@ -164,7 +164,7 @@ func EqError(err error, msg string) (s string) {
 }
 
 func ErrorIs(err error, target error) (s string) {
-	if err == nil {
+	if err == nil && target != nil {
 		s = "expected non-nil error; got nil\n"
 		return
 	}

--- a/must/must_test.go
+++ b/must/must_test.go
@@ -165,6 +165,10 @@ func TestErrorIs_nil(t *testing.T) {
 	ErrorIs(tc, nil, err)
 }
 
+func TestErrorIs_nil_nil(t *testing.T) {
+	ErrorIs(t, nil, nil)
+}
+
 type FakeError string
 
 func (e FakeError) Error() string {

--- a/test_test.go
+++ b/test_test.go
@@ -163,6 +163,10 @@ func TestErrorIs_nil(t *testing.T) {
 	ErrorIs(tc, nil, err)
 }
 
+func TestErrorIs_nil_nil(t *testing.T) {
+	ErrorIs(t, nil, nil)
+}
+
 type FakeError string
 
 func (e FakeError) Error() string {


### PR DESCRIPTION
Go's built-in `errors.Is` [returns true](SpikesDivZero/shoenig--test) when both target and err are nil, but this library marks the test as a failure.

I came across this while writing a table-based test, in which I had to work around this by writing:

```
test.True(t, errors.Is(err, tt.wantErrIs))
// -- OR --
if tt.wantErrIs == nil {
	test.Nil(t, err)
} else {
	test.ErrorIs(t, err, tt.wantErrIs)
}
```

After this change is applied, the test code can be reduced to a clear statement instead.