### PR TITLE
test: add Panic and NotPanic

### DIFF
--- a/examples_test.go
+++ b/examples_test.go
@@ -990,6 +990,16 @@ func ExampleUnreachable() {
 	// Output:
 }
 
+func ExamplePanic() {
+	Panic(t, func() { panic("hi mom") })
+	// Output:
+}
+
+func ExampleNotPanic() {
+	NotPanic(t, func() {})
+	// Output:
+}
+
 func ExampleValidJSON() {
 	js := `{"key": ["v1", "v2"]}`
 	ValidJSON(t, js)

--- a/internal/assertions/assertions.go
+++ b/internal/assertions/assertions.go
@@ -142,6 +142,26 @@ func Unreachable() (s string) {
 	return
 }
 
+func Panic(f func()) (s string) {
+	defer func() {
+		if r := recover(); r == nil {
+			s = "expected panic; did not panic"
+		}
+	}()
+	f()
+	return
+}
+
+func NotPanic(f func()) (s string) {
+	defer func() {
+		if r := recover(); r != nil {
+			s = fmt.Sprintf("expected not to panic; panicked: %v", r)
+		}
+	}()
+	f()
+	return
+}
+
 func Error(err error) (s string) {
 	if err == nil {
 		s = "expected non-nil error; got nil\n"

--- a/must/examples_test.go
+++ b/must/examples_test.go
@@ -992,6 +992,16 @@ func ExampleUnreachable() {
 	// Output:
 }
 
+func ExamplePanic() {
+	Panic(t, func() { panic("hi mom") })
+	// Output:
+}
+
+func ExampleNotPanic() {
+	NotPanic(t, func() {})
+	// Output:
+}
+
 func ExampleValidJSON() {
 	js := `{"key": ["v1", "v2"]}`
 	ValidJSON(t, js)

--- a/must/must.go
+++ b/must/must.go
@@ -51,6 +51,18 @@ func Unreachable(t T, settings ...Setting) {
 	invoke(t, assertions.Unreachable(), settings...)
 }
 
+// Panic asserts func f panics.
+func Panic(t T, f func(), settings ...Setting) {
+	t.Helper()
+	invoke(t, assertions.Panic(f), settings...)
+}
+
+// NotPanic asserts func f does not panic.
+func NotPanic(t T, f func(), settings ...Setting) {
+	t.Helper()
+	invoke(t, assertions.NotPanic(f), settings...)
+}
+
 // Error asserts err is a non-nil error.
 func Error(t T, err error, settings ...Setting) {
 	t.Helper()

--- a/test.go
+++ b/test.go
@@ -49,6 +49,18 @@ func Unreachable(t T, settings ...Setting) {
 	invoke(t, assertions.Unreachable(), settings...)
 }
 
+// Panic asserts func f panics.
+func Panic(t T, f func(), settings ...Setting) {
+	t.Helper()
+	invoke(t, assertions.Panic(f), settings...)
+}
+
+// NotPanic asserts func f does not panic.
+func NotPanic(t T, f func(), settings ...Setting) {
+	t.Helper()
+	invoke(t, assertions.NotPanic(f), settings...)
+}
+
 // Error asserts err is a non-nil error.
 func Error(t T, err error, settings ...Setting) {
 	t.Helper()


### PR DESCRIPTION
Hi Seth!

I don't wanna upgrade testify in hashicorp/nomad-pack#727, but we have some `require.Panicsf` and `require.NotPanicsf` calls that need replacing.

I could be persuaded to name these `Panics` and `NotPanics`, or if you told me to go jump off a bridge, and you had some good reasons, then I might be persuaded to do that, too.

Hope you're doing well! :green_heart: 