### PR TITLE
assertions: correct the type assertion of ErrorAs

### DIFF
--- a/examples_test.go
+++ b/examples_test.go
@@ -314,7 +314,7 @@ func ExampleErrorAs() {
 	e2 := fmt.Errorf("e2: %w", e1)
 	e3 := fmt.Errorf("e3: %w", e2)
 	var target FakeError
-	ErrorAs(t, e3, &target)
+	ErrorAs[FakeError](t, e3, &target)
 	fmt.Println(target.Error())
 	// Output: e1
 }

--- a/internal/assertions/assertions.go
+++ b/internal/assertions/assertions.go
@@ -196,13 +196,9 @@ func ErrorIs(err error, target error) (s string) {
 	return
 }
 
-func ErrorAs[E error, Target *E](err error, target Target) (s string) {
+func ErrorAs[E error, Target any](err error, target Target) (s string) {
 	if err == nil {
 		s = "expected non-nil error; got nil\n"
-		return
-	}
-	if target == nil {
-		s = "expected non-nil target; got nil\n"
 		return
 	}
 	if !errors.As(err, target) {

--- a/must/examples_test.go
+++ b/must/examples_test.go
@@ -316,7 +316,7 @@ func ExampleErrorAs() {
 	e2 := fmt.Errorf("e2: %w", e1)
 	e3 := fmt.Errorf("e3: %w", e2)
 	var target FakeError
-	ErrorAs(t, e3, &target)
+	ErrorAs[FakeError](t, e3, &target)
 	fmt.Println(target.Error())
 	// Output: e1
 }

--- a/must/must.go
+++ b/must/must.go
@@ -83,9 +83,9 @@ func ErrorIs(t T, err error, target error, settings ...Setting) {
 
 // ErrorAs asserts err's tree contains an error that matches target.
 // If so, it sets target to the error value.
-func ErrorAs[E error, Target *E](t T, err error, target Target, settings ...Setting) {
+func ErrorAs[E error, Target any](t T, err error, target Target, settings ...Setting) {
 	t.Helper()
-	invoke(t, assertions.ErrorAs(err, target), settings...)
+	invoke(t, assertions.ErrorAs[E](err, target), settings...)
 }
 
 // NoError asserts err is a nil error.

--- a/must/must_test.go
+++ b/must/must_test.go
@@ -181,7 +181,7 @@ func TestErrorAs(t *testing.T) {
 
 	var target FakeError
 	e := errors.New("foo")
-	ErrorAs(tc, e, &target)
+	ErrorAs[FakeError](tc, e, &target)
 }
 
 func TestErrorAs_nilErr(t *testing.T) {
@@ -189,16 +189,7 @@ func TestErrorAs_nilErr(t *testing.T) {
 	t.Cleanup(tc.assert)
 
 	var target FakeError
-	ErrorAs(tc, nil, &target)
-}
-
-func TestErrorAs_nilTarget(t *testing.T) {
-	tc := newCase(t, `expected non-nil target; got nil`)
-	t.Cleanup(tc.assert)
-
-	var target *FakeError
-	e := errors.New("foo")
-	ErrorAs(tc, e, target)
+	ErrorAs[FakeError](tc, nil, &target)
 }
 
 func TestNoError(t *testing.T) {

--- a/test.go
+++ b/test.go
@@ -81,9 +81,9 @@ func ErrorIs(t T, err error, target error, settings ...Setting) {
 
 // ErrorAs asserts err's tree contains an error that matches target.
 // If so, it sets target to the error value.
-func ErrorAs[E error, Target *E](t T, err error, target Target, settings ...Setting) {
+func ErrorAs[E error, Target any](t T, err error, target Target, settings ...Setting) {
 	t.Helper()
-	invoke(t, assertions.ErrorAs(err, target), settings...)
+	invoke(t, assertions.ErrorAs[E](err, target), settings...)
 }
 
 // NoError asserts err is a nil error.

--- a/test_test.go
+++ b/test_test.go
@@ -179,7 +179,7 @@ func TestErrorAs(t *testing.T) {
 
 	var target FakeError
 	e := errors.New("foo")
-	ErrorAs(tc, e, &target)
+	ErrorAs[FakeError](tc, e, &target)
 }
 
 func TestErrorAs_nilErr(t *testing.T) {
@@ -187,16 +187,7 @@ func TestErrorAs_nilErr(t *testing.T) {
 	t.Cleanup(tc.assert)
 
 	var target FakeError
-	ErrorAs(tc, nil, &target)
-}
-
-func TestErrorAs_nilTarget(t *testing.T) {
-	tc := newCase(t, `expected non-nil target; got nil`)
-	t.Cleanup(tc.assert)
-
-	var target *FakeError
-	e := errors.New("foo")
-	ErrorAs(tc, e, target)
+	ErrorAs[FakeError](tc, nil, &target)
 }
 
 func TestNoError(t *testing.T) {


### PR DESCRIPTION
After bumping the go directive version in go.mod to 1.21 the vet tool
is complaining about the ErrorAs assertion.

```
➜ go vet ./...
internal/assertions/assertions.go:208:6: second argument to errors.As must be a non-nil pointer to either a type that implements error, or to any interface type
```

The linter warning is a bit of a red-herring - in fact the `Target`
parameter for our `ErrorAs` assertion has been incorrect this whole time.
It should be `any`. Currently it is restricting types to be a concrete
type that implements the error interface, which is not a requirement of
`errors.As`.

In fact you can use `errors.As` to assert your `err` satisfies any interface
you choose - but the examples in the Go docs do not make this clear (imo).

For example you could have some error type:

```
type NetworkError interface {
    Error() error
    Timeout() bool
}
```

And you want to check if your error implements `Timeout()`, which you
can do using `errors.As`, e.g.

```
type IO interface {
    Timeout() bool
}

var io IO
if errors.As(networkError, &io) {
    timeout := io.Timeout()
    // ...
}
```

In this toy example we use `errors.As` detect if the underlying error
(which is `NetworkError`) satisfies the `IO` interface, and if so, populates
`io` with our error value, and call its `Timeout()` method.
